### PR TITLE
Fix imports

### DIFF
--- a/pandaplot/models/project/items/chart.py
+++ b/pandaplot/models/project/items/chart.py
@@ -8,7 +8,7 @@ from typing import Any, Dict, List, Optional
 
 import numpy as np
 
-from pandaplot.models.project.items import Item
+from pandaplot.models.project.items.item import Item
 
 
 @dataclass

--- a/pandaplot/models/project/items/dataset.py
+++ b/pandaplot/models/project/items/dataset.py
@@ -7,7 +7,7 @@ from typing import Any, Dict, Optional
 
 import pandas as pd
 
-from pandaplot.models.project.items import Item
+from pandaplot.models.project.items.item import Item
 
 
 class Dataset(Item):

--- a/pandaplot/models/project/items/folder.py
+++ b/pandaplot/models/project/items/folder.py
@@ -4,7 +4,7 @@ Folder model for managing folder items in the project hierarchy.
 
 from typing import Optional
 
-from pandaplot.models.project.items import ItemCollection
+from pandaplot.models.project.items.item import ItemCollection
 
 
 class Folder(ItemCollection):

--- a/pandaplot/models/project/items/note.py
+++ b/pandaplot/models/project/items/note.py
@@ -5,7 +5,7 @@ Note model for managing text-based note items in the project.
 from datetime import datetime
 from typing import Any, Dict, List, Optional
 
-from pandaplot.models.project.items import Item
+from pandaplot.models.project.items.item import Item
 
 
 class Note(Item):


### PR DESCRIPTION
This pull request updates import statements across several files to explicitly import `Item` and `ItemCollection` from `pandaplot.models.project.items.item` instead of the parent package. This change improves code clarity and prevents potential import errors.

**Refactoring imports for clarity and correctness:**

* Updated `chart.py`, `dataset.py`, and `note.py` to import `Item` directly from `pandaplot.models.project.items.item` rather than the package. [[1]](diffhunk://#diff-743ee262fb788a9ba74aa19dfa8da41b20f4e978f2e61c70e28ff8993c801629L11-R11) [[2]](diffhunk://#diff-3facbc7b532bde7ff16522fc44dde309fa3ae3fe573fb3264277aa2fd693de09L10-R10) [[3]](diffhunk://#diff-93febcd092cee974305c2c57a9176ba0ae72b560932367872dabf5a0ebb6fb96L8-R8)
* Updated `folder.py` to import `ItemCollection` from `pandaplot.models.project.items.item` instead of the package.