### PR TITLE
fit format equation

### DIFF
--- a/pandaplot/gui/components/sidebar/fit/fit_panel.py
+++ b/pandaplot/gui/components/sidebar/fit/fit_panel.py
@@ -547,18 +547,17 @@ class FitPanel(PWidget):
         perr = results['errors']
         param_names = results['param_names']
         r_squared = results['r_squared']
-        
+        params = results["params"]
+
         # Format equation
-        equation = self.fit_command.format_equation(fit_type, popt)
+        equation = self.fit_command.format_equation(fit_type, params)
         self.equation_label.setText(equation)
-        
+
         # Format results text
         results_text = f"Fit Type: {fit_type}\n\n"
         results_text += "Parameters:\n"
-        
-        for i, (name, value, error) in enumerate(zip(param_names, popt, perr)):
-            results_text += f"  {name} = {value:.6g} ± {error:.6g}\n"
-        
+        results_text += self.fit_command.format_parameters(param_names, params, perr)
+
         if r_squared is not None:
             results_text += f"\nR² = {r_squared:.6f}\n"
         
@@ -629,4 +628,4 @@ class FitPanel(PWidget):
             self.update_data_points_display()
 
 #TODO: fix equation box
-#TODO: fix custom equation display -2.3*x+b instead of 4.2*x-2.3
+#TODO: show confidence bands

--- a/pandaplot/services/fit/fit_service.py
+++ b/pandaplot/services/fit/fit_service.py
@@ -1,15 +1,14 @@
 import numpy as np
-import pandas as pd
 from scipy.optimize import curve_fit
 import logging
 
 from pandaplot.models.events import FitEvents
-from pandaplot.models.project.items import Dataset
 
 
 #performs fit, doesn't include combobox methods
 class FitService:
     def __init__(self, fit_panel):
+        self.fixed_params = None
         self.fit_results = None
         self.fit_panel = fit_panel
         self.logger = logging.getLogger(__name__)
@@ -66,8 +65,8 @@ class FitService:
                     key, val = item.split("=")
                     fixed_params[key.strip()] = float(val)
 
-        # free parameters for fit
-        free_params = [p for p in params if p not in fixed_params]
+        self.fixed_params = fixed_params.copy()
+        free_params = [p for p in params if p not in fixed_params] #free parameters for fit
 
         # Create function dynamically
         def custom_func(x, *free_args):
@@ -80,7 +79,7 @@ class FitService:
                 local_vars[p] = free_args[i]
             return eval(function_str, {"__builtins__": {}}, local_vars)
 
-        return custom_func, free_params
+        return custom_func, params
 
     def perform_fit(self): #fit_services
         """Perform the curve fitting."""
@@ -123,12 +122,25 @@ class FitService:
             x_fit = np.linspace(x_data.min(), x_data.max(), self.fit_panel.fit_points_spin.value())
             y_fit = fit_func(x_fit, *popt)
 
+            # param dictionary define
+            fixed_params = dict(self.fixed_params) if self.fixed_params else {}
+            params = {}
+            popt_index = 0
+
+            for name in param_names:
+                if name in fixed_params:
+                    params[name] = fixed_params[name]
+                else:
+                    params[name] = popt[popt_index]
+                    popt_index += 1
+
             # Store results
             self.fit_results = {
                 'fit_type': fit_type,
                 'parameters': popt,
                 'errors': perr,
                 'param_names': param_names,
+                'params': params,
                 'r_squared': r_squared,
                 'x_fit': x_fit,
                 'y_fit': y_fit,
@@ -156,33 +168,48 @@ class FitService:
             self.fit_panel.equation_label.setText("Fit failed")
             self.fit_panel.apply_button.setEnabled(False)
 
-    def format_equation(self, fit_type: str, params):
-        """Format the equation string."""
+    def format_equation(self, fit_type: str, params: dict):
         if "Linear" in fit_type:
-            a, b = params
-            return f"y = {a:.6g}x + {b:.6g}"
+            equation = "a*x + b"
         elif "Quadratic" in fit_type:
-            a, b, c = params
-            return f"y = {a:.6g}x² + {b:.6g}x + {c:.6g}"
+            equation = "a*x**2 + b*x + c"
         elif "Exponential" in fit_type:
-            a, b, c = params
-            return f"y = {a:.6g}e^({b:.6g}x) + {c:.6g}"
+            equation = "a*exp(b*x) + c"
         elif "Power" in fit_type:
-            a, b, c = params
-            return f"y = {a:.6g}x^{b:.6g} + {c:.6g}"
+            equation = "a*x**b + c"
         elif "Logarithmic" in fit_type:
-            a, b = params
-            return f"y = {a:.6g}ln(x) + {b:.6g}"
+            equation = "a*ln(x) + b"
         elif "Custom" in fit_type:
-            function_str = self.fit_panel.custom_function_edit.text().strip()
-            params_str = self.fit_panel.custom_params_edit.text().strip()
-            param_names = [p.strip() for p in params_str.split(",")]
-
-            # Substitute parameter values
-            equation = function_str
-            for name, value in zip(param_names, params):
-                equation = equation.replace(name, f"{value:.6g}")
-            return f"y = {equation}"
+            equation = self.fit_panel.custom_function_edit.text().strip()
         else:
             return "Unknown equation"
 
+        for name, value in params.items():
+            try:
+                num = float(value)
+                equation = equation.replace(name, f"{num:.6g}")
+            except ValueError:
+                equation = equation.replace(name, str(value))
+
+        equation = equation.replace("+-", "-").replace("+ -", "-")
+        return f"y = {equation}"
+
+    def format_parameters(self, param_names, params, errors):
+        """format fitted parameters for display"""
+        lines = []
+        fixed_params = self.fixed_params or {}
+        free_index = 0
+
+        for name in param_names:
+            value = params[name]
+            if name in fixed_params:
+                lines.append(f"  {name} = {value:.6g}  (fixed)")
+            else:
+                error = errors[free_index]
+                if np.isinf(error) or np.isnan(error):
+                    lines.append(f"  {name} = {value:.6g}  (no error estimate)")
+                else:
+                    lines.append(f"  {name} = {value:.6g} ± {error:.6g}")
+                free_index += 1
+
+        return "\n".join(lines)


### PR DESCRIPTION
Perform_fit() builds parameter dictionary containing fitted and fixed parameters which fixes equation formatting so that parameter values are substituted correctly, and expressions such as +-2.3 are displayed as -2.3.

Fixed parameters are now marked (fixed) in the fit results, and parameters whose uncertainty is ± inf now shows (no error estimate). Parameter formatting logic has been moved into FitService (format_parameters()).