### PR TITLE
chore: gitignore worktrees and internal working docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -208,3 +208,8 @@ __marimo__/
 
 .idea/
 docs/temp/*
+.worktrees/
+
+# Internal working docs (plans, specs, review notes) - kept local only
+docs/superpowers/
+docs/temp/


### PR DESCRIPTION
## Summary
- Gitignore `.worktrees/` and internal planning docs (`docs/superpowers/`, `docs/temp/`) so they never get committed
- Fixes a pre-existing bug where `.worktrees/` was accidentally concatenated onto the previous gitignore line (missing newline) and never actually took effect

## Test plan
- [x] No functional code changes; nothing to test beyond the gitignore behavior