### PR TITLE
feat: add About dialog and Examples browser

### DIFF
--- a/pandaplot/gui/components/main_menu/main_menu.py
+++ b/pandaplot/gui/components/main_menu/main_menu.py
@@ -1,7 +1,7 @@
 from typing import override
 
 from PySide6.QtGui import QAction, QKeySequence
-from PySide6.QtWidgets import QMenu, QMessageBox, QWidget
+from PySide6.QtWidgets import QMenu, QWidget
 
 from pandaplot.commands.app.exit_command import ExitCommand
 from pandaplot.commands.project.dataset import ImportCsvCommand
@@ -17,14 +17,10 @@ from pandaplot.commands.project.project import (
     SaveProjectCommand,
 )
 from pandaplot.gui.core.widget_extension import PMenuBar
+from pandaplot.gui.dialogs.about_dialog import AboutDialog
 from pandaplot.gui.dialogs.settings_dialog import SettingsDialog
 from pandaplot.models.state.app_context import AppContext
 from pandaplot.services.theme.theme_manager import ThemeManager
-
-
-def show_about():
-    # TODO: Implement a proper about dialog
-    QMessageBox.about(None, "About", "This is a sample app")
 
 
 class MainMenu(PMenuBar):
@@ -124,7 +120,7 @@ class MainMenu(PMenuBar):
         self.addMenu(help_menu)
 
         about_action = QAction("About", self)
-        about_action.triggered.connect(show_about)
+        about_action.triggered.connect(self.show_about_dialog)
         help_menu.addAction(about_action)
 
     def _create_file_menu(self) -> QMenu:
@@ -210,4 +206,9 @@ class MainMenu(PMenuBar):
     def show_settings_dialog(self):
         """Show the settings dialog."""
         dialog = SettingsDialog(self.app_context, self.parent())
+        dialog.exec()
+
+    def show_about_dialog(self):
+        """Show the about dialog."""
+        dialog = AboutDialog(self.app_context, self.parent())
         dialog.exec()

--- a/pandaplot/gui/components/tabs/tab_container.py
+++ b/pandaplot/gui/components/tabs/tab_container.py
@@ -204,6 +204,12 @@ class TabContainer(PWidget):
             command = LoadProjectCommand(self.app_context, project_path)
             self.app_context.get_command_executor().execute_command(command)
 
+    def handle_example_project(self, project_path: str):
+        """Handle example project selection from welcome tab."""
+        if self.app_context:
+            command = LoadProjectCommand(self.app_context, project_path)
+            self.app_context.get_command_executor().execute_command(command)
+
     def handle_import_data(self):
         """Handle import data request from welcome tab."""
         if self.app_context:
@@ -228,6 +234,7 @@ class TabContainer(PWidget):
         welcome_tab.open_project_requested.connect(self.handle_open_project)
         welcome_tab.recent_project_selected.connect(self.handle_recent_project)
         welcome_tab.import_data_requested.connect(self.handle_import_data)
+        welcome_tab.example_project_selected.connect(self.handle_example_project)
 
         self.tab_widget.addTab(welcome_tab, welcome_tab.get_tab_title())
         return welcome_tab

--- a/pandaplot/gui/components/tabs/welcome_tab.py
+++ b/pandaplot/gui/components/tabs/welcome_tab.py
@@ -18,12 +18,13 @@ from PySide6.QtWidgets import (
 )
 
 from pandaplot.gui.core.widget_extension import PWidget
+from pandaplot.gui.dialogs.examples_dialog import ExamplesDialog
 from pandaplot.models.events.event_types import ConfigEvents
 from pandaplot.models.state.app_context import AppContext
 from pandaplot.services.config.config_manager import ConfigManager
 from pandaplot.services.theme.theme_manager import ThemeManager
 
-    
+
 class WelcomeTab(PWidget):
     """
     Welcome tab widget similar to VS Code's welcome screen.
@@ -34,6 +35,7 @@ class WelcomeTab(PWidget):
     open_project_requested = Signal()
     recent_project_selected = Signal(str)  # project file path
     import_data_requested = Signal()  # importing data
+    example_project_selected = Signal(str)  # example project file path
 
     def __init__(self, app_context:AppContext, parent:QWidget):
         super().__init__(app_context=app_context, parent=parent)
@@ -251,12 +253,18 @@ class WelcomeTab(PWidget):
         examples_btn = self.create_action_button(
             "📚 Examples",
             "Browse sample projects and tutorials",
-            lambda: self.logger.info("Examples action triggered")  # TODO: Implement
+            self.show_examples_dialog
         )
         actions_layout.addWidget(examples_btn, 1, 1)
 
         layout.addLayout(actions_layout)
-    
+
+    def show_examples_dialog(self):
+        """Open the examples dialog and emit the chosen project's path, if any."""
+        dialog = ExamplesDialog(self.app_context, self)
+        if dialog.exec() and dialog.selected_path:
+            self.example_project_selected.emit(dialog.selected_path)
+
     def create_recent_projects_section(self, layout):
         """Create the recent projects section."""
         # Section title

--- a/pandaplot/gui/dialogs/about_dialog.py
+++ b/pandaplot/gui/dialogs/about_dialog.py
@@ -1,0 +1,145 @@
+"""About dialog for the PandaPlot application."""
+
+import platform
+from typing import override
+
+import matplotlib
+import pandas
+import PySide6
+from PySide6.QtCore import Qt
+from PySide6.QtWidgets import (
+    QFrame,
+    QGridLayout,
+    QHBoxLayout,
+    QLabel,
+    QPushButton,
+    QVBoxLayout,
+)
+
+from pandaplot.gui.core.widget_extension import PDialog
+from pandaplot.services.theme.theme_manager import ThemeManager
+from pandaplot.version import __app_name__, __description__, __version__
+
+
+class AboutDialog(PDialog):
+    """Shows application version, description, and runtime environment info."""
+
+    def __init__(self, app_context, parent=None):
+        super().__init__(app_context=app_context, parent=parent)
+        self._initialize()
+
+    @override
+    def _init_ui(self):
+        self.setWindowTitle(f"About {__app_name__}")
+        self.setModal(True)
+        self.setMinimumWidth(420)
+
+        layout = QVBoxLayout(self)
+        layout.setContentsMargins(24, 24, 24, 20)
+        layout.setSpacing(16)
+
+        self.icon_label = QLabel("🐼")
+        icon_font = self.icon_label.font()
+        icon_font.setPointSize(40)
+        self.icon_label.setFont(icon_font)
+        self.icon_label.setAlignment(Qt.AlignmentFlag.AlignCenter)
+        layout.addWidget(self.icon_label)
+
+        self.name_label = QLabel(__app_name__)
+        name_font = self.name_label.font()
+        name_font.setPointSize(20)
+        name_font.setBold(True)
+        self.name_label.setFont(name_font)
+        self.name_label.setAlignment(Qt.AlignmentFlag.AlignCenter)
+        layout.addWidget(self.name_label)
+
+        self.version_label = QLabel(f"Version {__version__}")
+        self.version_label.setAlignment(Qt.AlignmentFlag.AlignCenter)
+        layout.addWidget(self.version_label)
+
+        self.description_label = QLabel(__description__)
+        self.description_label.setWordWrap(True)
+        self.description_label.setAlignment(Qt.AlignmentFlag.AlignCenter)
+        layout.addWidget(self.description_label)
+
+        self.info_frame = QFrame()
+        self.info_frame.setObjectName("aboutInfoFrame")
+        info_layout = QGridLayout(self.info_frame)
+        info_layout.setContentsMargins(12, 12, 12, 12)
+        info_layout.setHorizontalSpacing(16)
+        info_layout.setVerticalSpacing(6)
+
+        environment_rows = [
+            ("Python", platform.python_version()),
+            ("PySide6 (Qt)", PySide6.__version__),
+            ("pandas", pandas.__version__),
+            ("Matplotlib", matplotlib.__version__),
+            ("Platform", f"{platform.system()} {platform.release()}"),
+        ]
+        self.info_value_labels = []
+        for row, (label_text, value_text) in enumerate(environment_rows):
+            key_label = QLabel(f"{label_text}:")
+            key_label.setProperty("secondary", True)
+            value_label = QLabel(value_text)
+            info_layout.addWidget(key_label, row, 0)
+            info_layout.addWidget(value_label, row, 1)
+            self.info_value_labels.append(value_label)
+        layout.addWidget(self.info_frame)
+
+        self.license_label = QLabel(
+            "Released under the MIT License.\nCopyright © 2025 Youth Research Center."
+        )
+        self.license_label.setAlignment(Qt.AlignmentFlag.AlignCenter)
+        self.license_label.setWordWrap(True)
+        layout.addWidget(self.license_label)
+
+        button_layout = QHBoxLayout()
+        button_layout.addStretch()
+        self.close_btn = QPushButton("Close")
+        self.close_btn.setDefault(True)
+        self.close_btn.clicked.connect(self.accept)
+        button_layout.addWidget(self.close_btn)
+        button_layout.addStretch()
+        layout.addLayout(button_layout)
+
+    @override
+    def _apply_theme(self):
+        theme_manager = self.app_context.get_manager(ThemeManager)
+        palette = theme_manager.get_surface_palette()
+
+        card_bg = palette.get("card_bg", "#f8f9fa")
+        card_border = palette.get("card_border", "#dee2e6")
+        base_fg = palette.get("base_fg", "#000000")
+        secondary_fg = palette.get("secondary_fg", "#555555")
+        accent = palette.get("accent", "#4A90E2")
+
+        self.setStyleSheet(f"""
+            QDialog {{
+                background-color: {card_bg};
+                color: {base_fg};
+            }}
+            QLabel {{
+                color: {base_fg};
+            }}
+            QLabel[secondary="true"] {{
+                color: {secondary_fg};
+            }}
+            QPushButton {{
+                background-color: {accent};
+                color: white;
+                border: none;
+                border-radius: 4px;
+                padding: 6px 20px;
+                font-weight: bold;
+            }}
+        """)
+        self.info_frame.setStyleSheet(f"""
+            QFrame#aboutInfoFrame {{
+                background-color: {card_bg};
+                border: 1px solid {card_border};
+                border-radius: 6px;
+            }}
+        """)
+        self.version_label.setStyleSheet(f"color: {secondary_fg};")
+        self.description_label.setStyleSheet(f"color: {secondary_fg};")
+        self.license_label.setStyleSheet(f"color: {secondary_fg}; font-size: 11px;")

--- a/pandaplot/gui/dialogs/examples_dialog.py
+++ b/pandaplot/gui/dialogs/examples_dialog.py
@@ -1,0 +1,170 @@
+"""Dialog for browsing and opening bundled example projects."""
+
+from typing import Optional, override
+
+from PySide6.QtCore import Qt
+from PySide6.QtWidgets import (
+    QFrame,
+    QLabel,
+    QPushButton,
+    QScrollArea,
+    QSizePolicy,
+    QVBoxLayout,
+    QWidget,
+)
+
+from pandaplot.gui.core.widget_extension import PDialog
+from pandaplot.services.theme.theme_manager import ThemeManager
+from pandaplot.utils.examples import discover_example_projects
+
+
+class ExamplesDialog(PDialog):
+    """Lets the user browse bundled example projects and pick one to open.
+
+    On acceptance, `selected_path` holds the chosen project's file path.
+    """
+
+    def __init__(self, app_context, parent=None):
+        super().__init__(app_context=app_context, parent=parent)
+        self.selected_path: Optional[str] = None
+        self._initialize()
+
+    @override
+    def _init_ui(self):
+        self.setWindowTitle("Examples")
+        self.setModal(True)
+        self.resize(520, 420)
+        self.setMinimumSize(420, 320)
+
+        layout = QVBoxLayout(self)
+        layout.setContentsMargins(20, 20, 20, 20)
+        layout.setSpacing(12)
+
+        self.title_label = QLabel("Example Projects")
+        title_font = self.title_label.font()
+        title_font.setPointSize(16)
+        title_font.setBold(True)
+        self.title_label.setFont(title_font)
+        layout.addWidget(self.title_label)
+
+        self.subtitle_label = QLabel("Open a bundled example to explore what PandaPlot can do.")
+        layout.addWidget(self.subtitle_label)
+
+        scroll_area = QScrollArea()
+        scroll_area.setWidgetResizable(True)
+        scroll_area.setFrameShape(QFrame.Shape.NoFrame)
+        scroll_area.setHorizontalScrollBarPolicy(Qt.ScrollBarPolicy.ScrollBarAlwaysOff)
+        scroll_area.setStyleSheet("background: transparent;")
+        scroll_area.viewport().setStyleSheet("background: transparent;")
+
+        list_widget = QWidget()
+        list_widget.setStyleSheet("background: transparent;")
+        self.list_layout = QVBoxLayout(list_widget)
+        self.list_layout.setContentsMargins(0, 0, 0, 0)
+        self.list_layout.setSpacing(10)
+
+        examples = discover_example_projects()
+        if not examples:
+            placeholder = QLabel("No example projects were found.")
+            placeholder.setProperty("secondary", True)
+            placeholder.setAlignment(Qt.AlignmentFlag.AlignCenter)
+            self.list_layout.addWidget(placeholder)
+        else:
+            for example in examples:
+                self.list_layout.addWidget(self._create_example_item(example))
+        self.list_layout.addStretch()
+
+        scroll_area.setWidget(list_widget)
+        layout.addWidget(scroll_area)
+
+        self.close_btn = QPushButton("Cancel")
+        self.close_btn.setObjectName("CancelButton")
+        self.close_btn.clicked.connect(self.reject)
+        layout.addWidget(self.close_btn, alignment=Qt.AlignmentFlag.AlignRight)
+
+    def _create_example_item(self, example: dict) -> QPushButton:
+        """Create a clickable card for one example project."""
+        button = QPushButton()
+        button.setObjectName("ExampleItemButton")
+        button.setMinimumHeight(64)
+        button.setSizePolicy(QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Fixed)
+        button.setCursor(Qt.CursorShape.PointingHandCursor)
+
+        item_layout = QVBoxLayout(button)
+        item_layout.setContentsMargins(14, 10, 14, 10)
+        item_layout.setSpacing(4)
+
+        name_label = QLabel(example["name"])
+        name_font = name_label.font()
+        name_font.setBold(True)
+        name_label.setFont(name_font)
+        name_label.setAlignment(Qt.AlignmentFlag.AlignLeft)
+        name_label.setTextInteractionFlags(Qt.TextInteractionFlag.NoTextInteraction)
+        item_layout.addWidget(name_label)
+
+        if example["description"]:
+            desc_label = QLabel(example["description"])
+            desc_label.setProperty("secondary", True)
+            desc_label.setWordWrap(True)
+            desc_label.setAlignment(Qt.AlignmentFlag.AlignLeft)
+            desc_label.setTextInteractionFlags(Qt.TextInteractionFlag.NoTextInteraction)
+            item_layout.addWidget(desc_label)
+
+        button.clicked.connect(lambda: self._on_example_chosen(example["path"]))
+        return button
+
+    def _on_example_chosen(self, path: str):
+        self.selected_path = path
+        self.accept()
+
+    @override
+    def _apply_theme(self):
+        theme_manager = self.app_context.get_manager(ThemeManager)
+        palette = theme_manager.get_surface_palette()
+
+        card_bg = palette.get("card_bg", "#f8f9fa")
+        card_hover = palette.get("card_hover", "#e9ecef")
+        card_pressed = palette.get("card_pressed", "#dee2e6")
+        card_border = palette.get("card_border", "#dee2e6")
+        base_fg = palette.get("base_fg", "#000000")
+        secondary_fg = palette.get("secondary_fg", "#555555")
+        accent = palette.get("accent", "#4A90E2")
+
+        self.setStyleSheet(f"""
+            QDialog {{
+                background-color: {card_bg};
+                color: {base_fg};
+            }}
+            QLabel {{
+                color: {base_fg};
+            }}
+            QLabel[secondary="true"] {{
+                color: {secondary_fg};
+            }}
+            QPushButton#ExampleItemButton {{
+                background-color: {card_bg};
+                border: 1px solid {card_border};
+                border-radius: 6px;
+                text-align: left;
+            }}
+            QPushButton#ExampleItemButton:hover {{
+                background-color: {card_hover};
+                border-color: {accent};
+            }}
+            QPushButton#ExampleItemButton:pressed {{
+                background-color: {card_pressed};
+            }}
+            QPushButton#ExampleItemButton QLabel {{
+                background: transparent;
+                border: 0px;
+            }}
+            QPushButton#CancelButton {{
+                background-color: {accent};
+                color: white;
+                border: none;
+                border-radius: 4px;
+                padding: 6px 16px;
+                font-weight: bold;
+            }}
+        """)
+        self.subtitle_label.setStyleSheet(f"color: {secondary_fg};")

--- a/pandaplot/utils/examples.py
+++ b/pandaplot/utils/examples.py
@@ -1,0 +1,49 @@
+"""Discovery of bundled example projects (.pplot files under the examples/ directory)."""
+
+import json
+import logging
+import zipfile
+from pathlib import Path
+from typing import TypedDict
+
+logger = logging.getLogger(__name__)
+
+
+class ExampleProject(TypedDict):
+    name: str
+    description: str
+    path: str
+
+
+def get_examples_dir() -> Path:
+    """Return the repo-root examples/ directory (sibling of the pandaplot package)."""
+    return Path(__file__).resolve().parent.parent.parent / "examples"
+
+
+def discover_example_projects(examples_dir: Path | None = None) -> list[ExampleProject]:
+    """Scan examples_dir for .pplot project files and read their name/description.
+
+    Each .pplot file is a zip archive containing a project.json with "name" and
+    "description" fields, so those are read directly from the file rather than
+    kept as a separate, easily-stale hardcoded list.
+    """
+    if examples_dir is None:
+        examples_dir = get_examples_dir()
+
+    if not examples_dir.is_dir():
+        return []
+
+    examples: list[ExampleProject] = []
+    for pplot_path in sorted(examples_dir.rglob("*.pplot")):
+        try:
+            with zipfile.ZipFile(pplot_path) as archive:
+                project_meta = json.loads(archive.read("project.json"))
+            examples.append({
+                "name": project_meta.get("name", pplot_path.stem),
+                "description": project_meta.get("description", ""),
+                "path": str(pplot_path),
+            })
+        except Exception as e:  # noqa: BLE001
+            logger.warning("Skipping unreadable example project '%s': %s", pplot_path, e)
+
+    return examples

--- a/pandaplot/version.py
+++ b/pandaplot/version.py
@@ -1,0 +1,34 @@
+"""Application version and metadata, sourced from pyproject.toml.
+
+Reads directly from pyproject.toml rather than importlib.metadata since the
+app is normally run from source (not installed as a package), so package
+metadata isn't available. Falls back to hardcoded values if the file can't
+be read (e.g. a future frozen/packaged build).
+"""
+
+import tomllib
+from pathlib import Path
+
+FALLBACK_NAME = "PandaPlot"
+FALLBACK_VERSION = "0.1.0"
+FALLBACK_DESCRIPTION = (
+    "PandaPlot is educational scientific visualization and analysis application "
+    "built with Python. The project is open source and welcomes contribution."
+)
+
+
+def _load_project_metadata() -> dict:
+    try:
+        pyproject_path = Path(__file__).resolve().parent.parent / "pyproject.toml"
+        with open(pyproject_path, "rb") as f:
+            data = tomllib.load(f)
+        return data.get("project", {})
+    except Exception:
+        return {}
+
+
+_project = _load_project_metadata()
+
+__version__ = _project.get("version", FALLBACK_VERSION)
+__app_name__ = "PandaPlot"
+__description__ = _project.get("description", FALLBACK_DESCRIPTION)

--- a/tests/utils/test_examples.py
+++ b/tests/utils/test_examples.py
@@ -1,0 +1,63 @@
+import json
+import zipfile
+from pathlib import Path
+
+from pandaplot.utils.examples import discover_example_projects
+
+
+def _write_pplot(path: Path, name: str, description: str):
+    with zipfile.ZipFile(path, "w") as archive:
+        archive.writestr("project.json", json.dumps({"name": name, "description": description}))
+
+
+class TestDiscoverExampleProjects:
+    def test_missing_directory_returns_empty_list(self, tmp_path):
+        assert discover_example_projects(tmp_path / "does-not-exist") == []
+
+    def test_empty_directory_returns_empty_list(self, tmp_path):
+        assert discover_example_projects(tmp_path) == []
+
+    def test_reads_name_and_description_from_each_pplot(self, tmp_path):
+        _write_pplot(tmp_path / "a.pplot", "Project A", "Description A")
+        _write_pplot(tmp_path / "b.pplot", "Project B", "Description B")
+
+        examples = discover_example_projects(tmp_path)
+
+        assert {e["name"] for e in examples} == {"Project A", "Project B"}
+        by_name = {e["name"]: e for e in examples}
+        assert by_name["Project A"]["description"] == "Description A"
+        assert by_name["Project A"]["path"] == str(tmp_path / "a.pplot")
+
+    def test_finds_pplot_files_in_subdirectories(self, tmp_path):
+        subdir = tmp_path / "nested"
+        subdir.mkdir()
+        _write_pplot(subdir / "nested.pplot", "Nested Project", "Nested description")
+
+        examples = discover_example_projects(tmp_path)
+
+        assert len(examples) == 1
+        assert examples[0]["name"] == "Nested Project"
+
+    def test_skips_corrupt_pplot_file(self, tmp_path):
+        (tmp_path / "corrupt.pplot").write_text("not a zip file")
+        _write_pplot(tmp_path / "valid.pplot", "Valid Project", "Valid description")
+
+        examples = discover_example_projects(tmp_path)
+
+        assert len(examples) == 1
+        assert examples[0]["name"] == "Valid Project"
+
+    def test_skips_pplot_without_project_json(self, tmp_path):
+        with zipfile.ZipFile(tmp_path / "no_meta.pplot", "w") as archive:
+            archive.writestr("items/something.json", "{}")
+
+        assert discover_example_projects(tmp_path) == []
+
+    def test_missing_name_falls_back_to_filename_stem(self, tmp_path):
+        with zipfile.ZipFile(tmp_path / "fallback.pplot", "w") as archive:
+            archive.writestr("project.json", json.dumps({"description": "No name field"}))
+
+        examples = discover_example_projects(tmp_path)
+
+        assert examples[0]["name"] == "fallback"
+        assert examples[0]["description"] == "No name field"


### PR DESCRIPTION
## Summary
- Replace the placeholder About message box with a real About dialog (backed by `pandaplot/version.py`)
- Add an Examples dialog that lists bundled example projects (`.pplot` files under `examples/`) and loads the selected one from the welcome tab

## Test plan
- [x] `pytest` passes on this branch (369 tests)
- [ ] Manually open About and Examples from the Help menu / welcome tab

Stacked on #62 — base will move down the stack as earlier PRs merge.