### PR TITLE
feat: error bars

### DIFF
--- a/pandaplot/commands/project/dataset/delete_columns_command.py
+++ b/pandaplot/commands/project/dataset/delete_columns_command.py
@@ -1,3 +1,4 @@
+from dataclasses import dataclass
 from typing import List, Tuple, Union, override
 
 from pandaplot.commands.base_command import Command
@@ -8,6 +9,14 @@ from pandaplot.models.project.items import Chart
 from pandaplot.models.project.items.dataset import Dataset
 from pandaplot.models.state.app_context import AppContext
 from pandaplot.models.state.app_state import AppState
+
+
+@dataclass
+class ChartReferenceMatch:
+    chart: Chart
+    series_indices: List[int]
+    fit_indices: List[int]
+    error_only_indices: List[int]
 
 
 class DeleteColumnsCommand(Command):
@@ -141,12 +150,12 @@ class DeleteColumnsCommand(Command):
             references = self._find_chart_references(self.column_names)
             if references:
                 details = "\n".join(
-                    f"{chart.name}: " + ", ".join(
-                        ([f"{len(series_idx)} series"] if series_idx else [])
-                        + ([f"{len(fit_idx)} fit curve(s)"] if fit_idx else [])
-                        + ([f"{len(error_only_idx)} series losing error bars"] if error_only_idx else [])
+                    f"{match.chart.name}: " + ", ".join(
+                        ([f"{len(match.series_indices)} series"] if match.series_indices else [])
+                        + ([f"{len(match.fit_indices)} fit curve(s)"] if match.fit_indices else [])
+                        + ([f"{len(match.error_only_indices)} series losing error bars"] if match.error_only_indices else [])
                     )
-                    for chart, series_idx, fit_idx, error_only_idx in references
+                    for match in references
                 )
                 proceed = self.ui_controller.show_confirmation(
                     "Delete Columns",
@@ -180,7 +189,7 @@ class DeleteColumnsCommand(Command):
 
     def _find_chart_references(
         self, column_names: List[str]
-    ) -> List[Tuple[Chart, List[int], List[int], List[int]]]:
+    ) -> List[ChartReferenceMatch]:
         """Find charts whose series/fits reference this dataset's columns.
 
         Returns a list of (chart, data_series indices, fit_data indices,
@@ -193,7 +202,7 @@ class DeleteColumnsCommand(Command):
         if not self.project:
             return []
         column_set = set(column_names)
-        matches: List[Tuple[Chart, List[int], List[int], List[int]]] = []
+        matches: List[ChartReferenceMatch] = []
         for item in self.project.get_all_items():
             if not isinstance(item, Chart):
                 continue
@@ -214,11 +223,11 @@ class DeleteColumnsCommand(Command):
                 and (fit.source_x_column in column_set or fit.source_y_column in column_set)
             ]
             if series_idx or fit_idx or error_only_idx:
-                matches.append((item, series_idx, fit_idx, error_only_idx))
+                matches.append(ChartReferenceMatch(item, series_idx, fit_idx, error_only_idx))
         return matches
 
     def _perform_deletion(
-        self, references: List[Tuple[Chart, List[int], List[int], List[int]]]
+        self, references: List[ChartReferenceMatch]
     ) -> None:
         """Drop the columns from the dataset and remove dependent chart references."""
         # Create new DataFrame with the columns removed
@@ -235,7 +244,11 @@ class DeleteColumnsCommand(Command):
         column_set = set(self.column_names)
         self.removed_chart_refs = {}
         self.cleared_error_refs = {}
-        for chart, series_idx, fit_idx, error_only_idx in references:
+        for match in references:
+            chart = match.chart
+            series_idx = match.series_indices
+            fit_idx = match.fit_indices
+            error_only_idx = match.error_only_indices
             removed_series = [(i, chart.data_series[i]) for i in series_idx]
             removed_fits = [(i, chart.fit_data[i]) for i in fit_idx]
 

--- a/pandaplot/commands/project/dataset/delete_columns_command.py
+++ b/pandaplot/commands/project/dataset/delete_columns_command.py
@@ -40,6 +40,12 @@ class DeleteColumnsCommand(Command):
         # populated when columns being deleted are referenced by chart series/fits
         self.removed_chart_refs = {}
 
+        # chart_id -> [(series_index, old_x_error_column, old_y_error_column)]
+        # populated when a deleted column is only referenced as an (optional)
+        # error-bar column, so the series survives with error bars cleared
+        # instead of being removed entirely
+        self.cleared_error_refs = {}
+
     @override
     def execute(self) -> bool:
         """Execute the delete columns command."""
@@ -138,14 +144,16 @@ class DeleteColumnsCommand(Command):
                     f"{chart.name}: " + ", ".join(
                         ([f"{len(series_idx)} series"] if series_idx else [])
                         + ([f"{len(fit_idx)} fit curve(s)"] if fit_idx else [])
+                        + ([f"{len(error_only_idx)} series losing error bars"] if error_only_idx else [])
                     )
-                    for chart, series_idx, fit_idx in references
+                    for chart, series_idx, fit_idx, error_only_idx in references
                 )
                 proceed = self.ui_controller.show_confirmation(
                     "Delete Columns",
                     f"{len(self.column_names)} column(s) are used by {len(references)} "
                     "chart(s). Deleting them will remove the dependent series/fit "
-                    "curves from those charts. Continue?",
+                    "curves from those charts (series only using the column for "
+                    "error bars will keep plotting, with error bars removed). Continue?",
                     details=details
                 )
                 if not proceed:
@@ -172,16 +180,20 @@ class DeleteColumnsCommand(Command):
 
     def _find_chart_references(
         self, column_names: List[str]
-    ) -> List[Tuple[Chart, List[int], List[int]]]:
+    ) -> List[Tuple[Chart, List[int], List[int], List[int]]]:
         """Find charts whose series/fits reference this dataset's columns.
 
-        Returns a list of (chart, data_series indices, fit_data indices) for
-        every chart with at least one matching reference.
+        Returns a list of (chart, data_series indices, fit_data indices,
+        error-only data_series indices) for every chart with at least one
+        matching reference. A series lands in error-only indices (instead of
+        data_series indices) when the only matching reference is its
+        optional x_error_column/y_error_column, since that series still
+        renders fine without error bars and shouldn't be removed.
         """
         if not self.project:
             return []
         column_set = set(column_names)
-        matches: List[Tuple[Chart, List[int], List[int]]] = []
+        matches: List[Tuple[Chart, List[int], List[int], List[int]]] = []
         for item in self.project.get_all_items():
             if not isinstance(item, Chart):
                 continue
@@ -190,16 +202,24 @@ class DeleteColumnsCommand(Command):
                 if series.dataset_id == self.dataset_id
                 and (series.x_column in column_set or series.y_column in column_set)
             ]
+            error_only_idx = [
+                i for i, series in enumerate(item.data_series)
+                if i not in series_idx and series.dataset_id == self.dataset_id
+                and (series.x_error_column in column_set or series.y_error_column in column_set
+                     or series.x_error_minus_column in column_set or series.y_error_minus_column in column_set)
+            ]
             fit_idx = [
                 i for i, fit in enumerate(item.fit_data)
                 if fit.source_dataset_id == self.dataset_id
                 and (fit.source_x_column in column_set or fit.source_y_column in column_set)
             ]
-            if series_idx or fit_idx:
-                matches.append((item, series_idx, fit_idx))
+            if series_idx or fit_idx or error_only_idx:
+                matches.append((item, series_idx, fit_idx, error_only_idx))
         return matches
 
-    def _perform_deletion(self, references: List[Tuple[Chart, List[int], List[int]]]) -> None:
+    def _perform_deletion(
+        self, references: List[Tuple[Chart, List[int], List[int], List[int]]]
+    ) -> None:
         """Drop the columns from the dataset and remove dependent chart references."""
         # Create new DataFrame with the columns removed
         new_data = self.dataset.data.drop(columns=self.column_names)
@@ -212,20 +232,46 @@ class DeleteColumnsCommand(Command):
                                       DatasetColumnsRemovedData(dataset_id=self.dataset_id, column_positions=self.column_positions).to_dict()
         )
 
+        column_set = set(self.column_names)
         self.removed_chart_refs = {}
-        for chart, series_idx, fit_idx in references:
+        self.cleared_error_refs = {}
+        for chart, series_idx, fit_idx, error_only_idx in references:
             removed_series = [(i, chart.data_series[i]) for i in series_idx]
             removed_fits = [(i, chart.fit_data[i]) for i in fit_idx]
+
+            # Clear error-only references using original indices before any
+            # deletion shifts the list, so `i` still points at the right series.
+            cleared_series = []
+            for i in error_only_idx:
+                series = chart.data_series[i]
+                old_values = (
+                    series.x_error_column, series.y_error_column,
+                    series.x_error_minus_column, series.y_error_minus_column,
+                )
+                if series.x_error_column in column_set:
+                    series.x_error_column = ""
+                if series.y_error_column in column_set:
+                    series.y_error_column = ""
+                if series.x_error_minus_column in column_set:
+                    series.x_error_minus_column = ""
+                if series.y_error_minus_column in column_set:
+                    series.y_error_minus_column = ""
+                cleared_series.append((i, *old_values))
+
             for i in sorted(series_idx, reverse=True):
                 del chart.data_series[i]
             for i in sorted(fit_idx, reverse=True):
                 del chart.fit_data[i]
-            if removed_series or removed_fits:
+
+            if removed_series or removed_fits or cleared_series:
                 chart.update_modified_time()
-                self.removed_chart_refs[chart.id] = {
-                    "series": removed_series,
-                    "fits": removed_fits,
-                }
+                if removed_series or removed_fits:
+                    self.removed_chart_refs[chart.id] = {
+                        "series": removed_series,
+                        "fits": removed_fits,
+                    }
+                if cleared_series:
+                    self.cleared_error_refs[chart.id] = cleared_series
                 self.app_state.event_bus.emit(ChartEvents.CHART_UPDATED, {
                     "chart_id": chart.id,
                     "chart": chart,
@@ -233,23 +279,34 @@ class DeleteColumnsCommand(Command):
 
     def _restore_chart_references(self) -> None:
         """Re-insert chart series/fits removed by _perform_deletion, for undo."""
-        if not self.project or not self.removed_chart_refs:
+        if not self.project or not (self.removed_chart_refs or self.cleared_error_refs):
             return
-        for chart_id, removed in self.removed_chart_refs.items():
+        chart_ids = set(self.removed_chart_refs) | set(self.cleared_error_refs)
+        for chart_id in chart_ids:
             chart = self.project.find_item(chart_id)
             if not isinstance(chart, Chart):
                 continue
+            removed = self.removed_chart_refs.get(chart_id, {"series": [], "fits": []})
             for i, series in sorted(removed["series"], key=lambda pair: pair[0]):
                 chart.data_series.insert(i, series)
             for i, fit in sorted(removed["fits"], key=lambda pair: pair[0]):
                 chart.fit_data.insert(i, fit)
-            if removed["series"] or removed["fits"]:
+
+            for i, old_x_err, old_y_err, old_x_err_minus, old_y_err_minus in self.cleared_error_refs.get(chart_id, []):
+                if 0 <= i < len(chart.data_series):
+                    chart.data_series[i].x_error_column = old_x_err
+                    chart.data_series[i].y_error_column = old_y_err
+                    chart.data_series[i].x_error_minus_column = old_x_err_minus
+                    chart.data_series[i].y_error_minus_column = old_y_err_minus
+
+            if removed["series"] or removed["fits"] or chart_id in self.cleared_error_refs:
                 chart.update_modified_time()
                 self.app_state.event_bus.emit(ChartEvents.CHART_UPDATED, {
                     "chart_id": chart.id,
                     "chart": chart,
                 })
         self.removed_chart_refs = {}
+        self.cleared_error_refs = {}
 
     def _resolve_columns(self):
         """

--- a/pandaplot/commands/project/dataset/rename_column_command.py
+++ b/pandaplot/commands/project/dataset/rename_column_command.py
@@ -119,6 +119,18 @@ class RenameColumnCommand(Command):
                 if series.y_column == from_name:
                     series.y_column = to_name
                     changed = True
+                if series.x_error_column == from_name:
+                    series.x_error_column = to_name
+                    changed = True
+                if series.y_error_column == from_name:
+                    series.y_error_column = to_name
+                    changed = True
+                if series.x_error_minus_column == from_name:
+                    series.x_error_minus_column = to_name
+                    changed = True
+                if series.y_error_minus_column == from_name:
+                    series.y_error_minus_column = to_name
+                    changed = True
             for fit in item.fit_data:
                 if fit.source_dataset_id != self.dataset_id:
                     continue

--- a/pandaplot/gui/components/sidebar/chart/chart_properties_panel.py
+++ b/pandaplot/gui/components/sidebar/chart/chart_properties_panel.py
@@ -28,7 +28,7 @@ from pandaplot.commands.project.chart import (
     RemoveFitDataCommand,
     RemoveSeriesCommand,
 )
-from pandaplot.models.project.items.chart import restore_chart_state, snapshot_chart_state
+from pandaplot.models.project.items.chart import ErrorDirection, restore_chart_state, snapshot_chart_state
 from pandaplot.gui.core.widget_extension import PWidget
 from pandaplot.models.chart.chart_configuration import (
     ChartType,
@@ -143,6 +143,7 @@ class ChartPropertiesPanel(PWidget):
 
         self._initialize()
         self._connect_signals()
+        self._update_error_bar_mode_controls()
     
     @override
     def _init_ui(self):
@@ -497,6 +498,39 @@ class ChartPropertiesPanel(PWidget):
         self.series_label_edit = QLineEdit()
         series_config_layout.addWidget(self.series_label_edit, 3, 1)
 
+        # Checked -> pick independent +/- error columns below; unchecked
+        # (default) -> a single column supplies a symmetric magnitude.
+        self.error_asymmetric_check = QCheckBox("Asymmetric Error Bars")
+        self.error_asymmetric_check.setToolTip(
+            "When checked, pick separate +/- error columns for independent "
+            "upper/lower magnitudes instead of one symmetric column.")
+        series_config_layout.addWidget(self.error_asymmetric_check, 4, 0, 1, 2)
+
+        # Label text switches between "X Error Column" (symmetric magnitude)
+        # and "X Error (+) Column" (asymmetric upper magnitude) depending on
+        # the checkbox above; see _update_error_bar_mode_controls.
+        self.x_error_column_label = QLabel("X Error Column:")
+        series_config_layout.addWidget(self.x_error_column_label, 5, 0)
+        self.x_error_column_combo = QComboBox()
+        series_config_layout.addWidget(self.x_error_column_combo, 5, 1)
+
+        self.y_error_column_label = QLabel("Y Error Column:")
+        series_config_layout.addWidget(self.y_error_column_label, 6, 0)
+        self.y_error_column_combo = QComboBox()
+        series_config_layout.addWidget(self.y_error_column_combo, 6, 1)
+
+        # Only shown when "Asymmetric Error Bars" is checked, to supply the
+        # lower-side (-) magnitude.
+        self.x_error_minus_label = QLabel("X Error (-) Column:")
+        series_config_layout.addWidget(self.x_error_minus_label, 7, 0)
+        self.x_error_minus_column_combo = QComboBox()
+        series_config_layout.addWidget(self.x_error_minus_column_combo, 7, 1)
+
+        self.y_error_minus_label = QLabel("Y Error (-) Column:")
+        series_config_layout.addWidget(self.y_error_minus_label, 8, 0)
+        self.y_error_minus_column_combo = QComboBox()
+        series_config_layout.addWidget(self.y_error_minus_column_combo, 8, 1)
+
         # Disable series configuration initially
         series_config_group.setEnabled(False)
         self.series_config_group = series_config_group
@@ -563,10 +597,36 @@ class ChartPropertiesPanel(PWidget):
         marker_layout.addWidget(self.marker_edge_color_button, 3, 1)
         
         layout.addWidget(marker_group)
-        
+
+        # Error bar style group (which columns feed the error bars is
+        # configured in Series Configuration, including the Asymmetric
+        # Error Bars checkbox; this group only controls how they render)
+        error_group = QGroupBox("Error Bars")
+        error_layout = QGridLayout(error_group)
+
+        error_layout.addWidget(QLabel("Direction:"), 0, 0)
+        self.error_direction_combo = QComboBox()
+        self.error_direction_combo.addItem("Both", ErrorDirection.BOTH)
+        self.error_direction_combo.addItem("Above (+)", ErrorDirection.PLUS)
+        self.error_direction_combo.addItem("Below (-)", ErrorDirection.MINUS)
+        error_layout.addWidget(self.error_direction_combo, 0, 1)
+
+        error_layout.addWidget(QLabel("Color:"), 1, 0)
+        self.error_color_button = ColorButton(self.app_context)
+        error_layout.addWidget(self.error_color_button, 1, 1)
+
+        error_layout.addWidget(QLabel("Cap Size:"), 2, 0)
+        self.error_cap_size_spin = QDoubleSpinBox()
+        self.error_cap_size_spin.setRange(0.0, 20.0)
+        self.error_cap_size_spin.setSingleStep(0.5)
+        self.error_cap_size_spin.setValue(3.0)
+        error_layout.addWidget(self.error_cap_size_spin, 2, 1)
+
+        layout.addWidget(error_group)
+
         layout.addStretch()
         return widget
-    
+
     def _create_axes_tab(self) -> QWidget:
         """Create the axes configuration tab."""
         widget = QWidget()
@@ -820,20 +880,29 @@ class ChartPropertiesPanel(PWidget):
         # Connect series configuration change signals
         self.x_column_combo.currentTextChanged.connect(self._on_series_config_changed)
         self.y_column_combo.currentTextChanged.connect(self._on_series_config_changed)
+        self.x_error_column_combo.currentIndexChanged.connect(self._on_series_config_changed)
+        self.y_error_column_combo.currentIndexChanged.connect(self._on_series_config_changed)
+        self.x_error_minus_column_combo.currentIndexChanged.connect(self._on_series_config_changed)
+        self.y_error_minus_column_combo.currentIndexChanged.connect(self._on_series_config_changed)
         # Defer label persistence to editingFinished to avoid disruptive refresh while typing
         self.series_label_edit.textChanged.connect(self._on_label_typing)
         self.series_label_edit.editingFinished.connect(self._on_label_committed)
-        
+
         # Connect style change signals
         self.line_color_button.colorChanged.connect(self._on_style_changed)
         self.line_width_spin.valueChanged.connect(self._on_style_changed)
         self.line_transparency_spin.valueChanged.connect(self._on_style_changed)
         self.line_style_combo.currentIndexChanged.connect(self._on_style_changed)
-        
+
         self.marker_color_button.colorChanged.connect(self._on_style_changed)
         self.marker_edge_color_button.colorChanged.connect(self._on_style_changed)
         self.marker_size_spin.valueChanged.connect(self._on_style_changed)
         self.marker_type_combo.currentIndexChanged.connect(self._on_style_changed)
+
+        self.error_asymmetric_check.toggled.connect(self._on_error_symmetry_toggled)
+        self.error_direction_combo.currentIndexChanged.connect(self._on_style_changed)
+        self.error_color_button.colorChanged.connect(self._on_style_changed)
+        self.error_cap_size_spin.valueChanged.connect(self._on_style_changed)
     
     def setup_event_subscriptions(self):
         """Set up event subscriptions for tab changes."""
@@ -1028,6 +1097,10 @@ class ChartPropertiesPanel(PWidget):
                 series.dataset_id = self.dataset_combo.currentData()
             series.x_column = self.x_column_combo.currentText()
             series.y_column = self.y_column_combo.currentText()
+            series.x_error_column = self.x_error_column_combo.currentData() or ""
+            series.y_error_column = self.y_error_column_combo.currentData() or ""
+            series.x_error_minus_column = self.x_error_minus_column_combo.currentData() or ""
+            series.y_error_minus_column = self.y_error_minus_column_combo.currentData() or ""
         else:
             # Fit data: columns/dataset not editable, ignore
             return
@@ -1066,7 +1139,17 @@ class ChartPropertiesPanel(PWidget):
                 series.line_style = self.line_style_combo.currentData().value
             if hasattr(self, "marker_type_combo") and self.marker_type_combo.currentData():
                 series.marker_style = self.marker_type_combo.currentData().value
-                
+
+            # Error bar style
+            if hasattr(self, "error_asymmetric_check"):
+                series.error_symmetric = not self.error_asymmetric_check.isChecked()
+            if hasattr(self, "error_direction_combo") and self.error_direction_combo.currentData():
+                series.error_direction = ErrorDirection(self.error_direction_combo.currentData())
+            if hasattr(self, "error_color_button"):
+                series.error_color = self.error_color_button.get_color()
+            if hasattr(self, "error_cap_size_spin"):
+                series.error_cap_size = self.error_cap_size_spin.value()
+
         else:
             # Updating fit data
             fit_index = current_row - total_series
@@ -1086,6 +1169,41 @@ class ChartPropertiesPanel(PWidget):
                 "chart_id": self.current_chart.id,
                 "update_type": "series_updated"
             })
+
+    def _on_error_symmetry_toggled(self):
+        """Handle the Asymmetric error-bars checkbox: persist and refresh control enablement."""
+        self._update_error_bar_mode_controls()
+        self._on_style_changed()
+
+    def _update_error_bar_mode_controls(self):
+        """Sync Series Configuration's error-column controls to the current
+        symmetric/asymmetric mode, and the Style tab's direction selector.
+
+        Unchecked (symmetric): X/Y Error Column supply a single magnitude
+        used with the Direction selector; the -side pickers are hidden.
+        Checked (asymmetric): X/Y Error Column become the + (upper)
+        magnitude and the -side pickers appear for the lower magnitude;
+        Direction no longer applies. Mirrors _update_hist_bins_visibility's
+        role of keeping mode-dependent controls in sync with their
+        governing choice.
+        """
+        asymmetric = self.error_asymmetric_check.isChecked()
+        self.error_direction_combo.setEnabled(not asymmetric)
+
+        self.x_error_column_label.setText("X Error (+) Column:" if asymmetric else "X Error Column:")
+        self.y_error_column_label.setText("Y Error (+) Column:" if asymmetric else "Y Error Column:")
+
+        # x_error_column_combo tracks whether a data series (vs. fit data,
+        # which has no error bars) is being edited; the -side pickers only
+        # show up when both a series is selected and asymmetric is checked.
+        show_minus = asymmetric and self.x_error_column_combo.isEnabled()
+        for widget in (
+            self.x_error_minus_label, self.x_error_minus_column_combo,
+            self.y_error_minus_label, self.y_error_minus_column_combo,
+        ):
+            widget.setVisible(show_minus)
+        self.x_error_minus_column_combo.setEnabled(show_minus)
+        self.y_error_minus_column_combo.setEnabled(show_minus)
 
     def _on_chart_type_index_changed(self):
         """Handle chart type combo changes, tracking explicit user intent.
@@ -1267,6 +1385,7 @@ class ChartPropertiesPanel(PWidget):
             # dataset/column state (e.g. after undo/redo of a column rename)
             # don't linger.
             self._populate_column_combos(series.dataset_id)
+            self._populate_error_column_combos(series.dataset_id)
 
             # Set columns
             x_index = self.x_column_combo.findText(series.x_column)
@@ -1276,6 +1395,18 @@ class ChartPropertiesPanel(PWidget):
             y_index = self.y_column_combo.findText(series.y_column)
             if y_index >= 0:
                 self.y_column_combo.setCurrentIndex(y_index)
+
+            # Set error columns (block signals while populating)
+            for combo, column in (
+                (self.x_error_column_combo, series.x_error_column),
+                (self.y_error_column_combo, series.y_error_column),
+                (self.x_error_minus_column_combo, series.x_error_minus_column),
+                (self.y_error_minus_column_combo, series.y_error_minus_column),
+            ):
+                combo.blockSignals(True)
+                index = combo.findData(column)
+                combo.setCurrentIndex(index if index >= 0 else 0)
+                combo.blockSignals(False)
 
             # Set label (block signals while populating)
             self.series_label_edit.blockSignals(True)
@@ -1326,6 +1457,30 @@ class ChartPropertiesPanel(PWidget):
                         self.marker_type_combo.setCurrentIndex(i)
                         break
                 self.marker_type_combo.blockSignals(False)
+
+            if hasattr(self, "error_asymmetric_check"):
+                self.error_asymmetric_check.blockSignals(True)
+                self.error_asymmetric_check.setChecked(not series.error_symmetric)
+                self.error_asymmetric_check.blockSignals(False)
+
+            if hasattr(self, "error_direction_combo"):
+                self.error_direction_combo.blockSignals(True)
+                direction_index = self.error_direction_combo.findData(series.error_direction)
+                self.error_direction_combo.setCurrentIndex(direction_index if direction_index >= 0 else 0)
+                self.error_direction_combo.blockSignals(False)
+
+            if hasattr(self, "error_color_button"):
+                self.error_color_button.blockSignals(True)
+                self.error_color_button.set_color(series.error_color or series.color)
+                self.error_color_button.blockSignals(False)
+
+            if hasattr(self, "error_cap_size_spin"):
+                self.error_cap_size_spin.blockSignals(True)
+                self.error_cap_size_spin.setValue(series.error_cap_size)
+                self.error_cap_size_spin.blockSignals(False)
+
+            if hasattr(self, "error_asymmetric_check"):
+                self._update_error_bar_mode_controls()
         finally:
             self._updating_controls = previous_guard
 
@@ -1338,6 +1493,10 @@ class ChartPropertiesPanel(PWidget):
             self.dataset_combo.setEnabled(False)
             self.x_column_combo.setEnabled(False)
             self.y_column_combo.setEnabled(False)
+            self.x_error_column_combo.setEnabled(False)
+            self.y_error_column_combo.setEnabled(False)
+            self.error_asymmetric_check.setEnabled(False)
+            self._update_error_bar_mode_controls()
 
             # Show fit info in the label (block signals)
             self.series_label_edit.blockSignals(True)
@@ -1395,6 +1554,11 @@ class ChartPropertiesPanel(PWidget):
         self.dataset_combo.setEnabled(True)
         self.x_column_combo.setEnabled(True)
         self.y_column_combo.setEnabled(True)
+        self.x_error_column_combo.setEnabled(True)
+        self.y_error_column_combo.setEnabled(True)
+        self.x_error_minus_column_combo.setEnabled(True)
+        self.y_error_minus_column_combo.setEnabled(True)
+        self.error_asymmetric_check.setEnabled(True)
 
     def _clear_controls(self):
         """Reset panel controls to neutral defaults without touching any chart."""
@@ -1472,10 +1636,41 @@ class ChartPropertiesPanel(PWidget):
             return columns
         return []
 
+    def _populate_error_column_combos(self, dataset_id):
+        """Fill the x/y (+/-) error column combos with a leading "None" entry
+        followed by the columns of the given dataset.
+
+        Signals are blocked while clearing/populating, same as
+        _populate_column_combos. Item data is the column name (or "" for
+        "None"), since "None" is itself a valid display label and can't be
+        distinguished from a real column via currentText().
+        """
+        combos = (
+            self.x_error_column_combo, self.y_error_column_combo,
+            self.x_error_minus_column_combo, self.y_error_minus_column_combo,
+        )
+        for combo in combos:
+            combo.blockSignals(True)
+        try:
+            for combo in combos:
+                combo.clear()
+                combo.addItem("None", "")
+
+            if dataset_id and self.current_project:
+                dataset = self.current_project.find_item(dataset_id)
+                if isinstance(dataset, Dataset) and dataset.data is not None:
+                    for column in dataset.data.columns:
+                        for combo in combos:
+                            combo.addItem(column, column)
+        finally:
+            for combo in combos:
+                combo.blockSignals(False)
+
     def _on_dataset_changed(self):
         """Handle dataset selection change."""
         dataset_id = self.dataset_combo.currentData()
         columns = self._populate_column_combos(dataset_id)
+        self._populate_error_column_combos(dataset_id)
 
         # Set defaults if possible
         if columns:
@@ -1745,6 +1940,15 @@ class ChartPropertiesPanel(PWidget):
                 if hasattr(self, "marker_type_combo") and self.marker_type_combo.currentData():
                     series.marker_style = self.marker_type_combo.currentData().value
 
+                if hasattr(self, "error_asymmetric_check"):
+                    series.error_symmetric = not self.error_asymmetric_check.isChecked()
+                if hasattr(self, "error_direction_combo") and self.error_direction_combo.currentData():
+                    series.error_direction = ErrorDirection(self.error_direction_combo.currentData())
+                if hasattr(self, "error_color_button"):
+                    series.error_color = self.error_color_button.get_color()
+                if hasattr(self, "error_cap_size_spin"):
+                    series.error_cap_size = self.error_cap_size_spin.value()
+
                 self.logger.debug(
                     "Applied style to data series %d: %s (color=%s, marker_color=%s)",
                     current_row, series.label, series.color, series.marker_color
@@ -1777,7 +1981,12 @@ class ChartPropertiesPanel(PWidget):
                     color=self.line_color_button.get_color(),
                     line_width=self.line_width_spin.value(),
                     marker_size=self.marker_size_spin.value(),
-                    label=f"{dataset_name}:{y_column}"
+                    label=f"{dataset_name}:{y_column}",
+                    x_error_column=self.x_error_column_combo.currentData() or "",
+                    y_error_column=self.y_error_column_combo.currentData() or "",
+                    x_error_minus_column=self.x_error_minus_column_combo.currentData() or "",
+                    y_error_minus_column=self.y_error_minus_column_combo.currentData() or "",
+                    error_symmetric=not self.error_asymmetric_check.isChecked(),
                 )
         
         chart.update_modified_time()

--- a/pandaplot/gui/components/tabs/chart/chart_editor.py
+++ b/pandaplot/gui/components/tabs/chart/chart_editor.py
@@ -529,8 +529,14 @@ class ChartEditorWidget(PWidget):
                                    if series.y_axis == "secondary" and self.chart_canvas.axes2 is not None
                                    else self.chart_canvas.axes)
 
-                    x_data, y_data, x_err, y_err, x_err_minus, y_err_minus, error = resolve_series_data(
-                        project, series, self.chart.chart_type)
+                    series_data = resolve_series_data(project, series, self.chart.chart_type)
+                    x_data = series_data.x_data
+                    y_data = series_data.y_data
+                    x_err = series_data.x_err
+                    y_err = series_data.y_err
+                    x_err_minus = series_data.x_err_minus
+                    y_err_minus = series_data.y_err_minus
+                    error = series_data.error
                     if error:
                         series_errors.append(
                             f"{series.label or f'Series {i + 1}'}: {error}")
@@ -576,7 +582,7 @@ class ChartEditorWidget(PWidget):
                         yerr = build_error_array(y_err, y_err_minus, series.error_direction, series.error_symmetric)
                         if xerr is not None or yerr is not None:
                             err_color = series.error_color or series.color
-                            self.chart_canvas.axes.errorbar(
+                            target_axes.errorbar(
                                 x_data, y_data,
                                 xerr=xerr,
                                 yerr=yerr,

--- a/pandaplot/gui/components/tabs/chart/chart_editor.py
+++ b/pandaplot/gui/components/tabs/chart/chart_editor.py
@@ -1,5 +1,6 @@
 from typing import override
 
+import numpy as np
 from matplotlib.ticker import AutoLocator, FuncFormatter, MaxNLocator, MultipleLocator, ScalarFormatter
 from PySide6.QtCore import Qt, QTimer
 from PySide6.QtGui import QAction
@@ -20,7 +21,7 @@ from shiboken6 import isValid
 from pandaplot.gui.components.tabs.chart.chart_canvas import ChartCanvas, cm_to_inches, fit_size_cm
 from pandaplot.gui.core.widget_extension import PWidget
 from pandaplot.models.events.event_types import ConfigEvents
-from pandaplot.models.project.items.chart import Chart
+from pandaplot.models.project.items.chart import Chart, ErrorDirection
 from pandaplot.models.state.app_context import AppContext
 from pandaplot.models.state.config import (
     MAX_CHART_HEIGHT_CM,
@@ -68,26 +69,42 @@ def apply_axis_ticks(axis, mode, count, step, fmt, custom_fmt):
         axis.set_major_formatter(ScalarFormatter())
 
 
+def _resolve_error_column(df, column_name):
+    """Best-effort lookup of an optional error column.
+
+    Returns None (never an error) when the column isn't configured or no
+    longer exists, so a stale error-column reference just silently drops
+    the error bars instead of hiding the whole series.
+    """
+    if not column_name or column_name not in df.columns:
+        return None
+    return df[column_name].to_numpy()
+
+
 def resolve_series_data(project, series, chart_type=None):
     """Resolve a DataSeries against the project's datasets.
 
-    Returns (x_data, y_data, None) on success, or (None, None, message)
-    when the dataset or a column can't be found. An empty x_column means
-    "plot against the DataFrame index". Histograms only ever plot
-    y_column, so a stale/unused x_column is ignored when chart_type == "hist".
+    Returns (x_data, y_data, x_err, y_err, x_err_minus, y_err_minus, None) on
+    success, or all-None with a message when the dataset or a required
+    column can't be found. An empty x_column means "plot against the
+    DataFrame index". Histograms only ever plot y_column, so a stale/unused
+    x_column is ignored when chart_type == "hist". The error columns are
+    resolved leniently (see _resolve_error_column) since they're optional;
+    x_err_minus/y_err_minus are only meaningful when series.error_symmetric
+    is False.
     """
     from pandaplot.models.project.items.dataset import Dataset
 
     if project is None:
-        return None, None, "no project loaded"
+        return None, None, None, None, None, None, "no project loaded"
 
     dataset = project.find_item(series.dataset_id)
     if not isinstance(dataset, Dataset) or dataset.data is None:
-        return None, None, f"dataset '{series.dataset_id}' not found"
+        return None, None, None, None, None, None, f"dataset '{series.dataset_id}' not found"
 
     df = dataset.data
     if not series.y_column:
-        return None, None, "no Y column configured"
+        return None, None, None, None, None, None, "no Y column configured"
 
     needs_x_column = chart_type != "hist"
     x_column = series.x_column if needs_x_column else None
@@ -96,10 +113,49 @@ def resolve_series_data(project, series, chart_type=None):
                if c and c not in df.columns]
     if missing:
         cols = ", ".join(f"'{c}'" for c in missing)
-        return None, None, f"column {cols} not found in '{dataset.name}'"
+        return None, None, None, None, None, None, f"column {cols} not found in '{dataset.name}'"
 
     x_data = df[x_column] if x_column else df.index
-    return x_data, df[series.y_column], None
+    x_err = _resolve_error_column(df, series.x_error_column)
+    y_err = _resolve_error_column(df, series.y_error_column)
+    x_err_minus = _resolve_error_column(df, series.x_error_minus_column)
+    y_err_minus = _resolve_error_column(df, series.y_error_minus_column)
+    return x_data, df[series.y_column], x_err, y_err, x_err_minus, y_err_minus, None
+
+
+def _symmetric_directional_error(magnitude, direction: ErrorDirection):
+    """Turn a symmetric error magnitude into the array matplotlib expects.
+
+    ErrorDirection.PLUS/MINUS produce an asymmetric (2, N) array with the
+    unused side zeroed out, since matplotlib's errorbar() only accepts a
+    single magnitude or an explicit lower/upper pair.
+    """
+    if magnitude is None:
+        return None
+    if direction == ErrorDirection.BOTH:
+        return magnitude
+    zeros = np.zeros_like(magnitude)
+    return np.vstack([zeros, magnitude]) if direction == ErrorDirection.PLUS else np.vstack([magnitude, zeros])
+
+
+def build_error_array(magnitude, minus_magnitude, direction, symmetric):
+    """Combine a series' resolved error column(s) into what errorbar() expects.
+
+    In symmetric mode only `magnitude` is used, expanded per `direction` via
+    _symmetric_directional_error. In asymmetric mode `magnitude` is the
+    upper (+) error and `minus_magnitude` the lower (-) error; either side
+    missing is treated as zero so a one-sided uncertainty column is still
+    usable on its own.
+    """
+    if symmetric:
+        return _symmetric_directional_error(magnitude, direction)
+    if magnitude is None and minus_magnitude is None:
+        return None
+    n = len(magnitude) if magnitude is not None else len(minus_magnitude)
+    zeros = np.zeros(n)
+    lower = minus_magnitude if minus_magnitude is not None else zeros
+    upper = magnitude if magnitude is not None else zeros
+    return np.vstack([lower, upper])
 
 
 class ChartEditorWidget(PWidget):
@@ -477,7 +533,7 @@ class ChartEditorWidget(PWidget):
             else:
                 project = self.app_context.get_app_state().current_project
                 for i, series in enumerate(self.chart.data_series):
-                    x_data, y_data, error = resolve_series_data(
+                    x_data, y_data, x_err, y_err, x_err_minus, y_err_minus, error = resolve_series_data(
                         project, series, self.chart.chart_type)
                     if error:
                         series_errors.append(
@@ -518,6 +574,21 @@ class ChartEditorWidget(PWidget):
                                                     color=series.color,
                                                     label=series.label,
                                                     alpha=alpha)
+
+                    if self.chart.chart_type in ("line", "scatter", "bar"):
+                        xerr = build_error_array(x_err, x_err_minus, series.error_direction, series.error_symmetric)
+                        yerr = build_error_array(y_err, y_err_minus, series.error_direction, series.error_symmetric)
+                        if xerr is not None or yerr is not None:
+                            err_color = series.error_color or series.color
+                            self.chart_canvas.axes.errorbar(
+                                x_data, y_data,
+                                xerr=xerr,
+                                yerr=yerr,
+                                fmt="none",
+                                ecolor=err_color,
+                                elinewidth=series.line_width,
+                                capsize=series.error_cap_size,
+                                alpha=alpha)
 
                 # Plot fit data from chart.fit_data
                 for i, fit in enumerate(self.chart.fit_data):

--- a/pandaplot/gui/components/tabs/chart/chart_editor.py
+++ b/pandaplot/gui/components/tabs/chart/chart_editor.py
@@ -1,4 +1,6 @@
 from typing import override
+from dataclasses import dataclass
+from typing import Optional, Any
 
 import numpy as np
 from matplotlib.ticker import AutoLocator, FuncFormatter, MaxNLocator, MultipleLocator, ScalarFormatter
@@ -81,7 +83,18 @@ def _resolve_error_column(df, column_name):
     return df[column_name].to_numpy()
 
 
-def resolve_series_data(project, series, chart_type=None):
+@dataclass
+class SeriesData:
+    x_data: Any
+    y_data: Any
+    x_err: Optional[Any]
+    y_err: Optional[Any]
+    x_err_minus: Optional[Any]
+    y_err_minus: Optional[Any]
+    error: Optional[str]
+
+
+def resolve_series_data(project, series, chart_type=None) -> SeriesData:
     """Resolve a DataSeries against the project's datasets.
 
     Returns (x_data, y_data, x_err, y_err, x_err_minus, y_err_minus, None) on
@@ -96,15 +109,15 @@ def resolve_series_data(project, series, chart_type=None):
     from pandaplot.models.project.items.dataset import Dataset
 
     if project is None:
-        return None, None, None, None, None, None, "no project loaded"
+        return SeriesData(None, None, None, None, None, None, "no project loaded")
 
     dataset = project.find_item(series.dataset_id)
     if not isinstance(dataset, Dataset) or dataset.data is None:
-        return None, None, None, None, None, None, f"dataset '{series.dataset_id}' not found"
+        return SeriesData(None, None, None, None, None, None, f"dataset '{series.dataset_id}' not found")
 
     df = dataset.data
     if not series.y_column:
-        return None, None, None, None, None, None, "no Y column configured"
+        return SeriesData(None, None, None, None, None, None, "no Y column configured")
 
     needs_x_column = chart_type != "hist"
     x_column = series.x_column if needs_x_column else None
@@ -113,14 +126,14 @@ def resolve_series_data(project, series, chart_type=None):
                if c and c not in df.columns]
     if missing:
         cols = ", ".join(f"'{c}'" for c in missing)
-        return None, None, None, None, None, None, f"column {cols} not found in '{dataset.name}'"
+        return SeriesData(None, None, None, None, None, None, f"column {cols} not found in '{dataset.name}'")
 
     x_data = df[x_column] if x_column else df.index
     x_err = _resolve_error_column(df, series.x_error_column)
     y_err = _resolve_error_column(df, series.y_error_column)
     x_err_minus = _resolve_error_column(df, series.x_error_minus_column)
     y_err_minus = _resolve_error_column(df, series.y_error_minus_column)
-    return x_data, df[series.y_column], x_err, y_err, x_err_minus, y_err_minus, None
+    return SeriesData(x_data, df[series.y_column], x_err, y_err, x_err_minus, y_err_minus, None)
 
 
 def _symmetric_directional_error(magnitude, direction: ErrorDirection):

--- a/pandaplot/gui/components/tabs/chart/chart_editor.py
+++ b/pandaplot/gui/components/tabs/chart/chart_editor.py
@@ -2,7 +2,6 @@ from typing import override
 from dataclasses import dataclass
 from typing import Optional, Any
 
-import numpy as np
 from matplotlib.ticker import AutoLocator, FuncFormatter, MaxNLocator, MultipleLocator, ScalarFormatter
 from PySide6.QtCore import Qt, QTimer
 from PySide6.QtGui import QAction
@@ -21,9 +20,10 @@ from PySide6.QtWidgets import (
 from shiboken6 import isValid
 
 from pandaplot.gui.components.tabs.chart.chart_canvas import ChartCanvas, cm_to_inches, fit_size_cm
+from pandaplot.gui.components.tabs.chart.chart_error_bars import build_error_array
 from pandaplot.gui.core.widget_extension import PWidget
 from pandaplot.models.events.event_types import ConfigEvents
-from pandaplot.models.project.items.chart import Chart, ErrorDirection
+from pandaplot.models.project.items.chart import Chart
 from pandaplot.models.state.app_context import AppContext
 from pandaplot.models.state.config import (
     MAX_CHART_HEIGHT_CM,
@@ -134,41 +134,6 @@ def resolve_series_data(project, series, chart_type=None) -> SeriesData:
     x_err_minus = _resolve_error_column(df, series.x_error_minus_column)
     y_err_minus = _resolve_error_column(df, series.y_error_minus_column)
     return SeriesData(x_data, df[series.y_column], x_err, y_err, x_err_minus, y_err_minus, None)
-
-
-def _symmetric_directional_error(magnitude, direction: ErrorDirection):
-    """Turn a symmetric error magnitude into the array matplotlib expects.
-
-    ErrorDirection.PLUS/MINUS produce an asymmetric (2, N) array with the
-    unused side zeroed out, since matplotlib's errorbar() only accepts a
-    single magnitude or an explicit lower/upper pair.
-    """
-    if magnitude is None:
-        return None
-    if direction == ErrorDirection.BOTH:
-        return magnitude
-    zeros = np.zeros_like(magnitude)
-    return np.vstack([zeros, magnitude]) if direction == ErrorDirection.PLUS else np.vstack([magnitude, zeros])
-
-
-def build_error_array(magnitude, minus_magnitude, direction, symmetric):
-    """Combine a series' resolved error column(s) into what errorbar() expects.
-
-    In symmetric mode only `magnitude` is used, expanded per `direction` via
-    _symmetric_directional_error. In asymmetric mode `magnitude` is the
-    upper (+) error and `minus_magnitude` the lower (-) error; either side
-    missing is treated as zero so a one-sided uncertainty column is still
-    usable on its own.
-    """
-    if symmetric:
-        return _symmetric_directional_error(magnitude, direction)
-    if magnitude is None and minus_magnitude is None:
-        return None
-    n = len(magnitude) if magnitude is not None else len(minus_magnitude)
-    zeros = np.zeros(n)
-    lower = minus_magnitude if minus_magnitude is not None else zeros
-    upper = magnitude if magnitude is not None else zeros
-    return np.vstack([lower, upper])
 
 
 class ChartEditorWidget(PWidget):

--- a/pandaplot/gui/components/tabs/chart/chart_error_bars.py
+++ b/pandaplot/gui/components/tabs/chart/chart_error_bars.py
@@ -1,0 +1,45 @@
+"""Helpers for turning a series' resolved error column(s) into the arrays
+matplotlib's ``Axes.errorbar()`` expects.
+
+Kept separate from the chart editor widget so the error-bar geometry can be
+unit-tested without any Qt/matplotlib widget setup.
+"""
+
+import numpy as np
+
+from pandaplot.models.project.items.chart import ErrorDirection
+
+
+def _symmetric_directional_error(magnitude, direction: ErrorDirection):
+    """Turn a symmetric error magnitude into the array matplotlib expects.
+
+    ErrorDirection.PLUS/MINUS produce an asymmetric (2, N) array with the
+    unused side zeroed out, since matplotlib's errorbar() only accepts a
+    single magnitude or an explicit lower/upper pair.
+    """
+    if magnitude is None:
+        return None
+    if direction == ErrorDirection.BOTH:
+        return magnitude
+    zeros = np.zeros_like(magnitude)
+    return np.vstack([zeros, magnitude]) if direction == ErrorDirection.PLUS else np.vstack([magnitude, zeros])
+
+
+def build_error_array(magnitude, minus_magnitude, direction, symmetric):
+    """Combine a series' resolved error column(s) into what errorbar() expects.
+
+    In symmetric mode only `magnitude` is used, expanded per `direction` via
+    _symmetric_directional_error. In asymmetric mode `magnitude` is the
+    upper (+) error and `minus_magnitude` the lower (-) error; either side
+    missing is treated as zero so a one-sided uncertainty column is still
+    usable on its own.
+    """
+    if symmetric:
+        return _symmetric_directional_error(magnitude, direction)
+    if magnitude is None and minus_magnitude is None:
+        return None
+    n = len(magnitude) if magnitude is not None else len(minus_magnitude)
+    zeros = np.zeros(n)
+    lower = minus_magnitude if minus_magnitude is not None else zeros
+    upper = magnitude if magnitude is not None else zeros
+    return np.vstack([lower, upper])

--- a/pandaplot/models/project/items/chart.py
+++ b/pandaplot/models/project/items/chart.py
@@ -6,7 +6,6 @@ import copy
 from dataclasses import asdict, dataclass
 from datetime import datetime
 from enum import StrEnum
-from enum import StrEnum
 from typing import Any, Dict, List, Optional
 
 import numpy as np

--- a/pandaplot/models/project/items/chart.py
+++ b/pandaplot/models/project/items/chart.py
@@ -5,11 +5,19 @@ Chart model for managing chart/visualization items in the project.
 import copy
 from dataclasses import asdict, dataclass
 from datetime import datetime
+from enum import StrEnum
 from typing import Any, Dict, List, Optional
 
 import numpy as np
 
 from pandaplot.models.project.items.item import Item
+
+
+class ErrorDirection(StrEnum):
+    """Which side(s) of a data point a symmetric error bar's magnitude is drawn on."""
+    BOTH = "both"
+    PLUS = "plus"
+    MINUS = "minus"
 
 
 @dataclass
@@ -28,6 +36,14 @@ class DataSeries:
     marker_size: float = 2.0
     visible: bool = True
     alpha: float = 1.0
+    x_error_column: str = ""
+    y_error_column: str = ""
+    x_error_minus_column: str = ""  # only used when error_symmetric is False
+    y_error_minus_column: str = ""  # only used when error_symmetric is False
+    error_symmetric: bool = True
+    error_direction: ErrorDirection = ErrorDirection.BOTH  # only used when error_symmetric is True
+    error_color: str = ""  # "" => inherit series.color
+    error_cap_size: float = 3.0
 
 
 @dataclass
@@ -309,7 +325,15 @@ class Chart(Item):
                     "line_width": series.line_width,
                     "marker_size": series.marker_size,
                     "visible": series.visible,
-                    "alpha": series.alpha
+                    "alpha": series.alpha,
+                    "x_error_column": series.x_error_column,
+                    "y_error_column": series.y_error_column,
+                    "x_error_minus_column": series.x_error_minus_column,
+                    "y_error_minus_column": series.y_error_minus_column,
+                    "error_symmetric": series.error_symmetric,
+                    "error_direction": series.error_direction,
+                    "error_color": series.error_color,
+                    "error_cap_size": series.error_cap_size
                 } for series in self.data_series
             ],
             "fit_data": [
@@ -370,7 +394,15 @@ class Chart(Item):
                 line_width=series_dict.get("line_width", 2.0),
                 marker_size=series_dict.get("marker_size", 2.0),
                 visible=series_dict.get("visible", True),
-                alpha=series_dict.get("alpha", 1.0)
+                alpha=series_dict.get("alpha", 1.0),
+                x_error_column=series_dict.get("x_error_column", ""),
+                y_error_column=series_dict.get("y_error_column", ""),
+                x_error_minus_column=series_dict.get("x_error_minus_column", ""),
+                y_error_minus_column=series_dict.get("y_error_minus_column", ""),
+                error_symmetric=series_dict.get("error_symmetric", True),
+                error_direction=ErrorDirection(series_dict.get("error_direction", ErrorDirection.BOTH)),
+                error_color=series_dict.get("error_color", ""),
+                error_cap_size=series_dict.get("error_cap_size", 3.0)
             )
             chart.data_series.append(series)
         

--- a/pandaplot/services/fit/fit_service.py
+++ b/pandaplot/services/fit/fit_service.py
@@ -1,5 +1,7 @@
 import logging
 import re
+from dataclasses import dataclass
+
 import numpy as np
 
 from pandaplot.models.events import FitEvents

--- a/tests/gui/test_chart_editor_series_resolution.py
+++ b/tests/gui/test_chart_editor_series_resolution.py
@@ -3,7 +3,8 @@
 import numpy as np
 import pandas as pd
 
-from pandaplot.gui.components.tabs.chart.chart_editor import build_error_array, resolve_series_data
+from pandaplot.gui.components.tabs.chart.chart_editor import resolve_series_data
+from pandaplot.gui.components.tabs.chart.chart_error_bars import build_error_array
 from pandaplot.models.project.items.chart import DataSeries, ErrorDirection
 from pandaplot.models.project.items.dataset import Dataset
 from pandaplot.models.project.project import Project
@@ -21,71 +22,71 @@ def _project_with_dataset():
 def test_resolves_x_and_y_columns():
     project, dataset = _project_with_dataset()
     series = DataSeries(dataset_id=dataset.id, x_column="a", y_column="b")
-    x, y, x_err, y_err, x_err_minus, y_err_minus, error = resolve_series_data(project, series)
-    assert error is None
-    assert list(x) == [1, 2]
-    assert list(y) == [3, 4]
-    assert x_err is None
-    assert y_err is None
-    assert x_err_minus is None
-    assert y_err_minus is None
+    result = resolve_series_data(project, series)
+    assert result.error is None
+    assert list(result.x_data) == [1, 2]
+    assert list(result.y_data) == [3, 4]
+    assert result.x_err is None
+    assert result.y_err is None
+    assert result.x_err_minus is None
+    assert result.y_err_minus is None
 
 
 def test_empty_x_column_uses_dataframe_index():
     project, dataset = _project_with_dataset()
     series = DataSeries(dataset_id=dataset.id, x_column="", y_column="b")
-    x, y, x_err, y_err, x_err_minus, y_err_minus, error = resolve_series_data(project, series)
-    assert error is None
-    assert list(x) == [0, 1]
+    result = resolve_series_data(project, series)
+    assert result.error is None
+    assert list(result.x_data) == [0, 1]
 
 
 def test_missing_dataset_returns_error():
     project, _ = _project_with_dataset()
     series = DataSeries(dataset_id="nope", x_column="a", y_column="b")
-    x, y, x_err, y_err, x_err_minus, y_err_minus, error = resolve_series_data(project, series)
-    assert x is None and y is None
-    assert "nope" in error
+    result = resolve_series_data(project, series)
+    assert result.x_data is None and result.y_data is None
+    assert "nope" in result.error
 
 
 def test_missing_column_returns_error_naming_the_column():
     project, dataset = _project_with_dataset()
     series = DataSeries(dataset_id=dataset.id, x_column="a", y_column="gone")
-    x, y, x_err, y_err, x_err_minus, y_err_minus, error = resolve_series_data(project, series)
-    assert x is None and y is None
-    assert "gone" in error
+    result = resolve_series_data(project, series)
+    assert result.x_data is None and result.y_data is None
+    assert "gone" in result.error
 
 
 def test_no_project_returns_error():
     series = DataSeries(dataset_id="ds", x_column="a", y_column="b")
-    x, y, x_err, y_err, x_err_minus, y_err_minus, error = resolve_series_data(None, series)
-    assert error is not None
+    result = resolve_series_data(None, series)
+    assert result.error is not None
 
 
 def test_histogram_ignores_stale_x_column():
     project, dataset = _project_with_dataset()
     series = DataSeries(dataset_id=dataset.id, x_column="gone", y_column="b")
-    x, y, x_err, y_err, x_err_minus, y_err_minus, error = resolve_series_data(project, series, chart_type="hist")
-    assert error is None
-    assert list(y) == [3, 4]
+    result = resolve_series_data(project, series, chart_type="hist")
+    assert result.error is None
+    assert list(result.y_data) == [3, 4]
 
 
 def test_resolves_y_error_column():
     project, dataset = _project_with_dataset()
     series = DataSeries(dataset_id=dataset.id, x_column="a", y_column="b", y_error_column="err")
-    x, y, x_err, y_err, x_err_minus, y_err_minus, error = resolve_series_data(project, series)
-    assert error is None
-    assert list(y_err) == [0.1, 0.2]
-    assert x_err is None
+    result = resolve_series_data(project, series)
+    assert result.error is None
+    assert list(result.y_err) == [0.1, 0.2]
+    assert result.x_err is None
 
 
 def test_missing_error_column_is_lenient():
     """A stale/unset error-column reference must not turn the whole series into an error."""
     project, dataset = _project_with_dataset()
     series = DataSeries(dataset_id=dataset.id, x_column="a", y_column="b", y_error_column="gone")
-    x, y, x_err, y_err, x_err_minus, y_err_minus, error = resolve_series_data(project, series)
-    assert error is None
-    assert list(y) == [3, 4]
-    assert y_err is None
+    result = resolve_series_data(project, series)
+    assert result.error is None
+    assert list(result.y_data) == [3, 4]
+    assert result.y_err is None
 
 
 def test_resolves_asymmetric_minus_column():
@@ -94,10 +95,10 @@ def test_resolves_asymmetric_minus_column():
         dataset_id=dataset.id, x_column="a", y_column="b",
         y_error_column="err", y_error_minus_column="err_minus", error_symmetric=False,
     )
-    x, y, x_err, y_err, x_err_minus, y_err_minus, error = resolve_series_data(project, series)
-    assert error is None
-    assert list(y_err) == [0.1, 0.2]
-    assert list(y_err_minus) == [0.05, 0.15]
+    result = resolve_series_data(project, series)
+    assert result.error is None
+    assert list(result.y_err) == [0.1, 0.2]
+    assert list(result.y_err_minus) == [0.05, 0.15]
 
 
 # --- build_error_array ---

--- a/tests/gui/test_chart_editor_series_resolution.py
+++ b/tests/gui/test_chart_editor_series_resolution.py
@@ -1,16 +1,19 @@
-"""Tests for resolve_series_data (no Qt widgets involved)."""
+"""Tests for resolve_series_data and build_error_array (no Qt widgets involved)."""
 
+import numpy as np
 import pandas as pd
 
-from pandaplot.gui.components.tabs.chart.chart_editor import resolve_series_data
-from pandaplot.models.project.items.chart import DataSeries
+from pandaplot.gui.components.tabs.chart.chart_editor import build_error_array, resolve_series_data
+from pandaplot.models.project.items.chart import DataSeries, ErrorDirection
 from pandaplot.models.project.items.dataset import Dataset
 from pandaplot.models.project.project import Project
 
 
 def _project_with_dataset():
     project = Project("P")
-    dataset = Dataset(name="ds", data=pd.DataFrame({"a": [1, 2], "b": [3, 4]}))
+    dataset = Dataset(name="ds", data=pd.DataFrame({
+        "a": [1, 2], "b": [3, 4], "err": [0.1, 0.2], "err_minus": [0.05, 0.15],
+    }))
     project.add_item(dataset)
     return project, dataset
 
@@ -18,16 +21,20 @@ def _project_with_dataset():
 def test_resolves_x_and_y_columns():
     project, dataset = _project_with_dataset()
     series = DataSeries(dataset_id=dataset.id, x_column="a", y_column="b")
-    x, y, error = resolve_series_data(project, series)
+    x, y, x_err, y_err, x_err_minus, y_err_minus, error = resolve_series_data(project, series)
     assert error is None
     assert list(x) == [1, 2]
     assert list(y) == [3, 4]
+    assert x_err is None
+    assert y_err is None
+    assert x_err_minus is None
+    assert y_err_minus is None
 
 
 def test_empty_x_column_uses_dataframe_index():
     project, dataset = _project_with_dataset()
     series = DataSeries(dataset_id=dataset.id, x_column="", y_column="b")
-    x, y, error = resolve_series_data(project, series)
+    x, y, x_err, y_err, x_err_minus, y_err_minus, error = resolve_series_data(project, series)
     assert error is None
     assert list(x) == [0, 1]
 
@@ -35,7 +42,7 @@ def test_empty_x_column_uses_dataframe_index():
 def test_missing_dataset_returns_error():
     project, _ = _project_with_dataset()
     series = DataSeries(dataset_id="nope", x_column="a", y_column="b")
-    x, y, error = resolve_series_data(project, series)
+    x, y, x_err, y_err, x_err_minus, y_err_minus, error = resolve_series_data(project, series)
     assert x is None and y is None
     assert "nope" in error
 
@@ -43,20 +50,96 @@ def test_missing_dataset_returns_error():
 def test_missing_column_returns_error_naming_the_column():
     project, dataset = _project_with_dataset()
     series = DataSeries(dataset_id=dataset.id, x_column="a", y_column="gone")
-    x, y, error = resolve_series_data(project, series)
+    x, y, x_err, y_err, x_err_minus, y_err_minus, error = resolve_series_data(project, series)
     assert x is None and y is None
     assert "gone" in error
 
 
 def test_no_project_returns_error():
     series = DataSeries(dataset_id="ds", x_column="a", y_column="b")
-    x, y, error = resolve_series_data(None, series)
+    x, y, x_err, y_err, x_err_minus, y_err_minus, error = resolve_series_data(None, series)
     assert error is not None
 
 
 def test_histogram_ignores_stale_x_column():
     project, dataset = _project_with_dataset()
     series = DataSeries(dataset_id=dataset.id, x_column="gone", y_column="b")
-    x, y, error = resolve_series_data(project, series, chart_type="hist")
+    x, y, x_err, y_err, x_err_minus, y_err_minus, error = resolve_series_data(project, series, chart_type="hist")
     assert error is None
     assert list(y) == [3, 4]
+
+
+def test_resolves_y_error_column():
+    project, dataset = _project_with_dataset()
+    series = DataSeries(dataset_id=dataset.id, x_column="a", y_column="b", y_error_column="err")
+    x, y, x_err, y_err, x_err_minus, y_err_minus, error = resolve_series_data(project, series)
+    assert error is None
+    assert list(y_err) == [0.1, 0.2]
+    assert x_err is None
+
+
+def test_missing_error_column_is_lenient():
+    """A stale/unset error-column reference must not turn the whole series into an error."""
+    project, dataset = _project_with_dataset()
+    series = DataSeries(dataset_id=dataset.id, x_column="a", y_column="b", y_error_column="gone")
+    x, y, x_err, y_err, x_err_minus, y_err_minus, error = resolve_series_data(project, series)
+    assert error is None
+    assert list(y) == [3, 4]
+    assert y_err is None
+
+
+def test_resolves_asymmetric_minus_column():
+    project, dataset = _project_with_dataset()
+    series = DataSeries(
+        dataset_id=dataset.id, x_column="a", y_column="b",
+        y_error_column="err", y_error_minus_column="err_minus", error_symmetric=False,
+    )
+    x, y, x_err, y_err, x_err_minus, y_err_minus, error = resolve_series_data(project, series)
+    assert error is None
+    assert list(y_err) == [0.1, 0.2]
+    assert list(y_err_minus) == [0.05, 0.15]
+
+
+# --- build_error_array ---
+
+def test_symmetric_both_direction_returns_raw_magnitude():
+    magnitude = np.array([0.1, 0.2])
+    result = build_error_array(magnitude, None, direction=ErrorDirection.BOTH, symmetric=True)
+    assert list(result) == [0.1, 0.2]
+
+
+def test_symmetric_plus_direction_zeroes_lower_side():
+    magnitude = np.array([0.1, 0.2])
+    result = build_error_array(magnitude, None, direction=ErrorDirection.PLUS, symmetric=True)
+    assert list(result[0]) == [0.0, 0.0]
+    assert list(result[1]) == [0.1, 0.2]
+
+
+def test_symmetric_no_magnitude_returns_none():
+    assert build_error_array(None, None, direction=ErrorDirection.BOTH, symmetric=True) is None
+
+
+def test_asymmetric_combines_plus_and_minus_columns():
+    plus = np.array([0.1, 0.2])
+    minus = np.array([0.05, 0.15])
+    result = build_error_array(plus, minus, direction=ErrorDirection.BOTH, symmetric=False)
+    assert list(result[0]) == [0.05, 0.15]
+    assert list(result[1]) == [0.1, 0.2]
+
+
+def test_asymmetric_missing_minus_side_defaults_to_zero():
+    plus = np.array([0.1, 0.2])
+    result = build_error_array(plus, None, direction=ErrorDirection.BOTH, symmetric=False)
+    assert list(result[0]) == [0.0, 0.0]
+    assert list(result[1]) == [0.1, 0.2]
+
+
+def test_asymmetric_missing_plus_side_defaults_to_zero():
+    minus = np.array([0.05, 0.15])
+    result = build_error_array(None, minus, direction=ErrorDirection.BOTH, symmetric=False)
+    assert list(result[0]) == [0.05, 0.15]
+    assert list(result[1]) == [0.0, 0.0]
+
+
+def test_asymmetric_no_columns_returns_none():
+    assert build_error_array(None, None, direction=ErrorDirection.BOTH, symmetric=False) is None

--- a/tests/models/test_error_direction_enum.py
+++ b/tests/models/test_error_direction_enum.py
@@ -1,0 +1,50 @@
+"""
+Unit tests for ErrorDirection, the StrEnum backing DataSeries.error_direction.
+
+Covers:
+- ErrorDirection compares equal to its plain string value (StrEnum contract)
+- DataSeries defaults to ErrorDirection.BOTH
+- Chart serialization round-trips error_direction as an ErrorDirection member,
+  including loading an older/hand-written plain-string save file
+"""
+
+from pandaplot.models.project.items.chart import Chart, DataSeries, ErrorDirection
+
+
+def test_error_direction_is_a_str_enum():
+    assert ErrorDirection.BOTH == "both"
+    assert ErrorDirection.PLUS == "plus"
+    assert ErrorDirection.MINUS == "minus"
+    assert isinstance(ErrorDirection.BOTH, str)
+
+
+def test_data_series_defaults_to_both():
+    series = DataSeries(dataset_id="ds1", x_column="x", y_column="y")
+    assert series.error_direction is ErrorDirection.BOTH
+
+
+def test_chart_serialization_round_trips_error_direction():
+    chart = Chart(name="Test Chart", chart_type="line")
+    chart.add_data_series(
+        dataset_id="ds1", x_column="x", y_column="y", error_direction=ErrorDirection.PLUS
+    )
+
+    data = chart.to_dict()
+    assert data["data_series"][0]["error_direction"] == "plus"
+
+    restored = Chart.from_dict(data)
+    assert restored.data_series[0].error_direction is ErrorDirection.PLUS
+
+
+def test_chart_deserialization_coerces_plain_string_to_enum():
+    """Older saves (or hand-edited project files) store a plain string;
+    from_dict must still hand back a real ErrorDirection member."""
+    chart = Chart(name="Test Chart", chart_type="line")
+    data = chart.to_dict()
+    data["data_series"] = [{
+        "dataset_id": "ds1", "x_column": "x", "y_column": "y",
+        "error_direction": "minus",
+    }]
+
+    restored = Chart.from_dict(data)
+    assert restored.data_series[0].error_direction is ErrorDirection.MINUS


### PR DESCRIPTION
Resolves #14 

Adds configurable error bars to chart data series (Line/Scatter/Bar), supporting both symmetric and asymmetric magnitudes sourced from dataset columns.

Data model (DataSeries): new x_error_column/y_error_column (+ x_error_minus_column/y_error_minus_column for asymmetric mode), error_symmetric flag, error_direction (now a proper ErrorDirection StrEnum — BOTH/PLUS/MINUS — instead of a raw string), error_color, error_cap_size. Fully wired into to_dict/from_dict for persistence, with legacy plain-string values still coerced correctly on load.

Rendering (chart_editor.py): error columns are resolved leniently (a missing/stale column just drops the error bars rather than breaking the whole series) and drawn via matplotlib.axes.errorbar() alongside the existing line/scatter/bar marks.

UI (ChartPropertiesPanel): Series Configuration gained an "Asymmetric Error Bars" checkbox plus X/Y error-column pickers — unchecked shows a single symmetric column pair, checked reveals separate +/- column pickers (with dynamic label updates and the Direction dropdown auto-disabling itself since it doesn't apply in asymmetric mode). Style tab gained Direction/Color/Cap Size controls for how the bars render.

Cascades: renaming a dataset column keeps error-bar references in sync; deleting a column that's only used as an error reference clears just that reference (with undo support) instead of deleting the whole series.

Incidental fix: fit_service.py was missing from dataclasses import dataclass, which broke app startup entirely — fixed as a one-liner since it blocked verifying this feature in the running app.