### PR TITLE
feat: statistical tests

### DIFF
--- a/pandaplot/analysis/__init__.py
+++ b/pandaplot/analysis/__init__.py
@@ -4,13 +4,22 @@ Analysis module for mathematical operations on data.
 
 from .analysis_engine import AnalysisEngine
 from .analysis_types import AnalysisParameters, AnalysisResult, AnalysisType, DerivativeMethod, InterpolationMethod, SmoothingMethod
+from .stats_engine import StatsEngine
+from .stats_types import STAT_TESTS, Alternative, InputMode, StatTestInfo, StatTestResult, StatTestType
 
 __all__ = [
     "AnalysisEngine",
     "AnalysisType",
-    "AnalysisResult", 
+    "AnalysisResult",
     "AnalysisParameters",
     "DerivativeMethod",
     "SmoothingMethod",
-    "InterpolationMethod"
+    "InterpolationMethod",
+    "StatsEngine",
+    "StatTestType",
+    "StatTestInfo",
+    "StatTestResult",
+    "InputMode",
+    "Alternative",
+    "STAT_TESTS",
 ]

--- a/pandaplot/analysis/stats_engine.py
+++ b/pandaplot/analysis/stats_engine.py
@@ -1,0 +1,507 @@
+"""
+Statistical testing engine.
+
+Provides a thin, well-documented wrapper around ``scipy.stats`` for the most
+frequently used hypothesis tests. Every test returns a :class:`StatTestResult`
+so the guided UI can present output consistently and add it to the project as
+data.
+"""
+
+import logging
+from typing import List, Sequence
+
+import numpy as np
+import pandas as pd
+
+from .stats_types import STAT_TESTS, StatTestResult, StatTestType
+
+logger = logging.getLogger(__name__)
+
+
+def _fmt(value: float, digits: int = 6) -> str:
+    """Format a float compactly, guarding against NaN/inf."""
+    if value is None or (isinstance(value, float) and (np.isnan(value) or np.isinf(value))):
+        return "n/a"
+    return f"{value:.{digits}g}"
+
+
+def _fmt_p(p: float) -> str:
+    """Format a p-value, using scientific notation for very small values."""
+    if p is None or np.isnan(p):
+        return "n/a"
+    if p < 1e-4:
+        return f"{p:.2e}"
+    return f"{p:.6f}"
+
+
+def _clean(series: pd.Series) -> np.ndarray:
+    """Coerce a column to a clean 1-D float array, dropping NaNs."""
+    values = pd.to_numeric(series, errors="coerce").to_numpy(dtype=float)
+    return values[~np.isnan(values)]
+
+
+def _clean_pair(a: pd.Series, b: pd.Series) -> tuple[np.ndarray, np.ndarray]:
+    """Coerce two columns to aligned float arrays, dropping rows with any NaN."""
+    frame = pd.DataFrame({"a": pd.to_numeric(a, errors="coerce"), "b": pd.to_numeric(b, errors="coerce")}).dropna()
+    return frame["a"].to_numpy(dtype=float), frame["b"].to_numpy(dtype=float)
+
+
+def _cohens_d(a: np.ndarray, b: np.ndarray) -> float:
+    """Cohen's d effect size for two independent samples (pooled SD)."""
+    n1, n2 = len(a), len(b)
+    if n1 < 2 or n2 < 2:
+        return float("nan")
+    var1, var2 = np.var(a, ddof=1), np.var(b, ddof=1)
+    pooled = np.sqrt(((n1 - 1) * var1 + (n2 - 1) * var2) / (n1 + n2 - 2))
+    if pooled == 0:
+        return float("nan")
+    return float((np.mean(a) - np.mean(b)) / pooled)
+
+
+def _effect_label(magnitude: float) -> str:
+    """Rough qualitative label for a |Cohen's d|-style effect size."""
+    m = abs(magnitude)
+    if np.isnan(m):
+        return "unknown"
+    if m < 0.2:
+        return "negligible"
+    if m < 0.5:
+        return "small"
+    if m < 0.8:
+        return "medium"
+    return "large"
+
+
+def _corr_strength(r: float) -> str:
+    """Qualitative label for a correlation coefficient magnitude."""
+    m = abs(r)
+    if np.isnan(m):
+        return "unknown"
+    if m < 0.1:
+        return "negligible"
+    if m < 0.3:
+        return "weak"
+    if m < 0.5:
+        return "moderate"
+    if m < 0.7:
+        return "strong"
+    return "very strong"
+
+
+class StatsEngine:
+    """Runs statistical hypothesis tests and returns structured results."""
+
+    @staticmethod
+    def run_test(
+        test_type: StatTestType,
+        columns: Sequence[pd.Series],
+        alpha: float = 0.05,
+        alternative: str = "two-sided",
+        popmean: float = 0.0,
+        equal_var: bool = True,
+    ) -> StatTestResult:
+        """
+        Run the requested statistical test.
+
+        Args:
+            test_type: Which test to run.
+            columns: Data columns (as pandas Series). The number required depends
+                on the test's input mode (one, two, or many columns).
+            alpha: Significance level for the plain-language conclusion.
+            alternative: Alternative hypothesis ('two-sided', 'less', 'greater').
+            popmean: Expected population mean for the one-sample t-test.
+            equal_var: Assume equal variance for the independent t-test (Welch if False).
+
+        Returns:
+            A populated :class:`StatTestResult`.
+        """
+        dispatch = {
+            StatTestType.ONE_SAMPLE_T: StatsEngine._one_sample_t,
+            StatTestType.INDEPENDENT_T: StatsEngine._independent_t,
+            StatTestType.PAIRED_T: StatsEngine._paired_t,
+            StatTestType.MANN_WHITNEY: StatsEngine._mann_whitney,
+            StatTestType.WILCOXON: StatsEngine._wilcoxon,
+            StatTestType.ONE_WAY_ANOVA: StatsEngine._one_way_anova,
+            StatTestType.KRUSKAL_WALLIS: StatsEngine._kruskal_wallis,
+            StatTestType.PEARSON: StatsEngine._pearson,
+            StatTestType.SPEARMAN: StatsEngine._spearman,
+            StatTestType.SHAPIRO: StatsEngine._shapiro,
+        }
+        handler = dispatch.get(test_type)
+        if handler is None:
+            raise ValueError(f"Unsupported test type: {test_type}")
+
+        return handler(
+            columns,
+            alpha=alpha,
+            alternative=alternative,
+            popmean=popmean,
+            equal_var=equal_var,
+        )
+
+    # ------------------------------------------------------------------
+    # Individual tests
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _one_sample_t(columns, *, alpha, alternative, popmean, equal_var) -> StatTestResult:
+        from scipy import stats
+
+        sample = _clean(columns[0])
+        name = str(columns[0].name)
+        StatsEngine._require(len(sample) >= 2, "at least 2 valid observations")
+
+        res = stats.ttest_1samp(sample, popmean=popmean, alternative=alternative)
+        stat, p = float(res.statistic), float(res.pvalue)
+        dof = len(sample) - 1
+        mean = float(np.mean(sample))
+        d = (mean - popmean) / np.std(sample, ddof=1) if np.std(sample, ddof=1) > 0 else float("nan")
+
+        rows = [
+            ("Test", "One-sample t-test"),
+            ("Column", name),
+            ("H0", f"mean = {popmean}"),
+            ("Alternative", alternative),
+            ("N", len(sample)),
+            ("Sample mean", _fmt(mean)),
+            ("Population mean", _fmt(popmean)),
+            ("t-statistic", _fmt(stat)),
+            ("Degrees of freedom", dof),
+            ("p-value", _fmt_p(p)),
+            ("Cohen's d", _fmt(d)),
+            ("Effect size", _effect_label(d)),
+            ("Significance level", alpha),
+        ]
+        return StatsEngine._build(
+            StatTestType.ONE_SAMPLE_T, "One-sample t-test", [name], stat, p, alpha, rows,
+            subject=f"the mean of '{name}' differs from {popmean}",
+        )
+
+    @staticmethod
+    def _independent_t(columns, *, alpha, alternative, popmean, equal_var) -> StatTestResult:
+        from scipy import stats
+
+        a, b = _clean(columns[0]), _clean(columns[1])
+        na, nb = str(columns[0].name), str(columns[1].name)
+        StatsEngine._require(len(a) >= 2 and len(b) >= 2, "at least 2 valid observations per group")
+
+        res = stats.ttest_ind(a, b, equal_var=equal_var, alternative=alternative)
+        stat, p = float(res.statistic), float(res.pvalue)
+        d = _cohens_d(a, b)
+        method = "Student's t-test" if equal_var else "Welch's t-test"
+
+        rows = [
+            ("Test", f"Independent t-test ({method})"),
+            ("Group A", na),
+            ("Group B", nb),
+            ("H0", "mean(A) = mean(B)"),
+            ("Alternative", alternative),
+            ("N (A)", len(a)),
+            ("N (B)", len(b)),
+            ("Mean (A)", _fmt(np.mean(a))),
+            ("Mean (B)", _fmt(np.mean(b))),
+            ("Equal variance assumed", equal_var),
+            ("t-statistic", _fmt(stat)),
+            ("p-value", _fmt_p(p)),
+            ("Cohen's d", _fmt(d)),
+            ("Effect size", _effect_label(d)),
+            ("Significance level", alpha),
+        ]
+        return StatsEngine._build(
+            StatTestType.INDEPENDENT_T, "Independent t-test", [na, nb], stat, p, alpha, rows,
+            subject=f"the means of '{na}' and '{nb}' differ",
+        )
+
+    @staticmethod
+    def _paired_t(columns, *, alpha, alternative, popmean, equal_var) -> StatTestResult:
+        from scipy import stats
+
+        a, b = _clean_pair(columns[0], columns[1])
+        na, nb = str(columns[0].name), str(columns[1].name)
+        StatsEngine._require(len(a) >= 2, "at least 2 complete pairs")
+
+        res = stats.ttest_rel(a, b, alternative=alternative)
+        stat, p = float(res.statistic), float(res.pvalue)
+        diff = a - b
+        d = np.mean(diff) / np.std(diff, ddof=1) if np.std(diff, ddof=1) > 0 else float("nan")
+
+        rows = [
+            ("Test", "Paired t-test"),
+            ("Column A", na),
+            ("Column B", nb),
+            ("H0", "mean difference = 0"),
+            ("Alternative", alternative),
+            ("N pairs", len(a)),
+            ("Mean difference", _fmt(np.mean(diff))),
+            ("t-statistic", _fmt(stat)),
+            ("Degrees of freedom", len(a) - 1),
+            ("p-value", _fmt_p(p)),
+            ("Cohen's d", _fmt(d)),
+            ("Effect size", _effect_label(d)),
+            ("Significance level", alpha),
+        ]
+        return StatsEngine._build(
+            StatTestType.PAIRED_T, "Paired t-test", [na, nb], stat, p, alpha, rows,
+            subject=f"the paired measurements '{na}' and '{nb}' differ",
+        )
+
+    @staticmethod
+    def _mann_whitney(columns, *, alpha, alternative, popmean, equal_var) -> StatTestResult:
+        from scipy import stats
+
+        a, b = _clean(columns[0]), _clean(columns[1])
+        na, nb = str(columns[0].name), str(columns[1].name)
+        StatsEngine._require(len(a) >= 1 and len(b) >= 1, "at least 1 valid observation per group")
+
+        res = stats.mannwhitneyu(a, b, alternative=alternative)
+        stat, p = float(res.statistic), float(res.pvalue)
+        # Rank-biserial correlation as effect size.
+        rbc = 1 - (2 * stat) / (len(a) * len(b)) if len(a) and len(b) else float("nan")
+
+        rows = [
+            ("Test", "Mann-Whitney U test"),
+            ("Group A", na),
+            ("Group B", nb),
+            ("H0", "distributions of A and B are equal"),
+            ("Alternative", alternative),
+            ("N (A)", len(a)),
+            ("N (B)", len(b)),
+            ("Median (A)", _fmt(np.median(a))),
+            ("Median (B)", _fmt(np.median(b))),
+            ("U-statistic", _fmt(stat)),
+            ("p-value", _fmt_p(p)),
+            ("Rank-biserial r", _fmt(rbc)),
+            ("Significance level", alpha),
+        ]
+        return StatsEngine._build(
+            StatTestType.MANN_WHITNEY, "Mann-Whitney U test", [na, nb], stat, p, alpha, rows,
+            subject=f"the distributions of '{na}' and '{nb}' differ",
+        )
+
+    @staticmethod
+    def _wilcoxon(columns, *, alpha, alternative, popmean, equal_var) -> StatTestResult:
+        from scipy import stats
+
+        a, b = _clean_pair(columns[0], columns[1])
+        na, nb = str(columns[0].name), str(columns[1].name)
+        StatsEngine._require(len(a) >= 1, "at least 1 complete pair")
+
+        res = stats.wilcoxon(a, b, alternative=alternative)
+        stat, p = float(res.statistic), float(res.pvalue)
+
+        rows = [
+            ("Test", "Wilcoxon signed-rank test"),
+            ("Column A", na),
+            ("Column B", nb),
+            ("H0", "median difference = 0"),
+            ("Alternative", alternative),
+            ("N pairs", len(a)),
+            ("Median difference", _fmt(np.median(a - b))),
+            ("W-statistic", _fmt(stat)),
+            ("p-value", _fmt_p(p)),
+            ("Significance level", alpha),
+        ]
+        return StatsEngine._build(
+            StatTestType.WILCOXON, "Wilcoxon signed-rank test", [na, nb], stat, p, alpha, rows,
+            subject=f"the paired measurements '{na}' and '{nb}' differ",
+        )
+
+    @staticmethod
+    def _one_way_anova(columns, *, alpha, alternative, popmean, equal_var) -> StatTestResult:
+        from scipy import stats
+
+        groups = [_clean(c) for c in columns]
+        names = [str(c.name) for c in columns]
+        StatsEngine._require(len(groups) >= 2, "at least 2 groups")
+        StatsEngine._require(all(len(g) >= 2 for g in groups), "at least 2 valid observations per group")
+
+        res = stats.f_oneway(*groups)
+        stat, p = float(res.statistic), float(res.pvalue)
+
+        # eta-squared effect size = SS_between / SS_total.
+        grand = np.concatenate(groups)
+        grand_mean = np.mean(grand)
+        ss_between = sum(len(g) * (np.mean(g) - grand_mean) ** 2 for g in groups)
+        ss_total = np.sum((grand - grand_mean) ** 2)
+        eta_sq = ss_between / ss_total if ss_total > 0 else float("nan")
+
+        rows = [
+            ("Test", "One-way ANOVA"),
+            ("Groups", ", ".join(names)),
+            ("H0", "all group means are equal"),
+            ("Number of groups", len(groups)),
+            ("Total N", len(grand)),
+            ("F-statistic", _fmt(stat)),
+            ("df between", len(groups) - 1),
+            ("df within", len(grand) - len(groups)),
+            ("p-value", _fmt_p(p)),
+            ("Eta-squared", _fmt(eta_sq)),
+            ("Significance level", alpha),
+        ]
+        return StatsEngine._build(
+            StatTestType.ONE_WAY_ANOVA, "One-way ANOVA", names, stat, p, alpha, rows,
+            subject="at least one group mean differs from the others",
+        )
+
+    @staticmethod
+    def _kruskal_wallis(columns, *, alpha, alternative, popmean, equal_var) -> StatTestResult:
+        from scipy import stats
+
+        groups = [_clean(c) for c in columns]
+        names = [str(c.name) for c in columns]
+        StatsEngine._require(len(groups) >= 2, "at least 2 groups")
+        StatsEngine._require(all(len(g) >= 1 for g in groups), "at least 1 valid observation per group")
+
+        res = stats.kruskal(*groups)
+        stat, p = float(res.statistic), float(res.pvalue)
+
+        rows = [
+            ("Test", "Kruskal-Wallis H test"),
+            ("Groups", ", ".join(names)),
+            ("H0", "all groups have the same distribution"),
+            ("Number of groups", len(groups)),
+            ("Total N", sum(len(g) for g in groups)),
+            ("H-statistic", _fmt(stat)),
+            ("Degrees of freedom", len(groups) - 1),
+            ("p-value", _fmt_p(p)),
+            ("Significance level", alpha),
+        ]
+        return StatsEngine._build(
+            StatTestType.KRUSKAL_WALLIS, "Kruskal-Wallis H test", names, stat, p, alpha, rows,
+            subject="at least one group distribution differs from the others",
+        )
+
+    @staticmethod
+    def _pearson(columns, *, alpha, alternative, popmean, equal_var) -> StatTestResult:
+        from scipy import stats
+
+        a, b = _clean_pair(columns[0], columns[1])
+        na, nb = str(columns[0].name), str(columns[1].name)
+        StatsEngine._require(len(a) >= 3, "at least 3 complete pairs")
+
+        res = stats.pearsonr(a, b, alternative=alternative)
+        r, p = float(res.statistic), float(res.pvalue)
+
+        rows = [
+            ("Test", "Pearson correlation"),
+            ("Variable X", na),
+            ("Variable Y", nb),
+            ("H0", "no linear correlation (r = 0)"),
+            ("Alternative", alternative),
+            ("N pairs", len(a)),
+            ("Correlation r", _fmt(r)),
+            ("R-squared", _fmt(r * r)),
+            ("Strength", _corr_strength(r)),
+            ("p-value", _fmt_p(p)),
+            ("Significance level", alpha),
+        ]
+        return StatsEngine._build(
+            StatTestType.PEARSON, "Pearson correlation", [na, nb], r, p, alpha, rows,
+            subject=f"'{na}' and '{nb}' are linearly correlated",
+        )
+
+    @staticmethod
+    def _spearman(columns, *, alpha, alternative, popmean, equal_var) -> StatTestResult:
+        from scipy import stats
+
+        a, b = _clean_pair(columns[0], columns[1])
+        na, nb = str(columns[0].name), str(columns[1].name)
+        StatsEngine._require(len(a) >= 3, "at least 3 complete pairs")
+
+        res = stats.spearmanr(a, b, alternative=alternative)
+        rho, p = float(res.statistic), float(res.pvalue)
+
+        rows = [
+            ("Test", "Spearman rank correlation"),
+            ("Variable X", na),
+            ("Variable Y", nb),
+            ("H0", "no monotonic correlation (rho = 0)"),
+            ("Alternative", alternative),
+            ("N pairs", len(a)),
+            ("Correlation rho", _fmt(rho)),
+            ("Strength", _corr_strength(rho)),
+            ("p-value", _fmt_p(p)),
+            ("Significance level", alpha),
+        ]
+        return StatsEngine._build(
+            StatTestType.SPEARMAN, "Spearman rank correlation", [na, nb], rho, p, alpha, rows,
+            subject=f"'{na}' and '{nb}' are monotonically correlated",
+        )
+
+    @staticmethod
+    def _shapiro(columns, *, alpha, alternative, popmean, equal_var) -> StatTestResult:
+        from scipy import stats
+
+        sample = _clean(columns[0])
+        name = str(columns[0].name)
+        StatsEngine._require(len(sample) >= 3, "at least 3 valid observations")
+
+        res = stats.shapiro(sample)
+        stat, p = float(res.statistic), float(res.pvalue)
+
+        rows = [
+            ("Test", "Shapiro-Wilk normality test"),
+            ("Column", name),
+            ("H0", "data is normally distributed"),
+            ("N", len(sample)),
+            ("W-statistic", _fmt(stat)),
+            ("p-value", _fmt_p(p)),
+            ("Significance level", alpha),
+        ]
+        # For normality the "significant" interpretation is inverted, so build a
+        # custom conclusion rather than the generic reject/fail helper.
+        if p < alpha:
+            conclusion = (
+                f"Reject H0 (p = {_fmt_p(p)} < {alpha}): the data in '{name}' is likely NOT normally distributed. "
+                "Consider a nonparametric test."
+            )
+        else:
+            conclusion = (
+                f"Fail to reject H0 (p = {_fmt_p(p)} >= {alpha}): no evidence that '{name}' departs from normality."
+            )
+        result = StatsEngine._build(
+            StatTestType.SHAPIRO, "Shapiro-Wilk normality test", [name], stat, p, alpha, rows, subject="",
+        )
+        result.conclusion = conclusion
+        result.rows.append(("Conclusion", conclusion))
+        return result
+
+    # ------------------------------------------------------------------
+    # Helpers
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _require(condition: bool, requirement: str) -> None:
+        if not condition:
+            raise ValueError(f"This test requires {requirement}.")
+
+    @staticmethod
+    def _build(
+        test_type: StatTestType,
+        test_name: str,
+        source_columns: List[str],
+        statistic: float,
+        p_value: float,
+        alpha: float,
+        rows: list,
+        subject: str,
+    ) -> StatTestResult:
+        """Assemble a StatTestResult and append a plain-language conclusion row."""
+        result = StatTestResult(
+            test_type=test_type,
+            test_name=test_name,
+            source_columns=source_columns,
+            statistic=statistic,
+            p_value=p_value,
+            alpha=alpha,
+            rows=list(rows),
+            metadata={"info": STAT_TESTS[test_type].label},
+        )
+        if subject:
+            if p_value < alpha:
+                conclusion = f"Reject H0 (p = {_fmt_p(p_value)} < {alpha}): evidence that {subject}."
+            else:
+                conclusion = f"Fail to reject H0 (p = {_fmt_p(p_value)} >= {alpha}): no significant evidence that {subject}."
+            result.conclusion = conclusion
+            result.rows.append(("Conclusion", conclusion))
+        return result

--- a/pandaplot/analysis/stats_types.py
+++ b/pandaplot/analysis/stats_types.py
@@ -1,0 +1,175 @@
+"""
+Types and metadata for guided statistical hypothesis testing.
+
+This module defines the catalog of supported statistical tests together with
+the metadata the guided UI needs to render inputs and help text, plus the
+result container used to surface test output in the application as data.
+"""
+
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import Any, Dict, List, Tuple
+
+import pandas as pd
+
+
+class StatTestType(Enum):
+    """Supported statistical tests."""
+
+    ONE_SAMPLE_T = "one_sample_t"
+    INDEPENDENT_T = "independent_t"
+    PAIRED_T = "paired_t"
+    MANN_WHITNEY = "mann_whitney"
+    WILCOXON = "wilcoxon"
+    ONE_WAY_ANOVA = "one_way_anova"
+    KRUSKAL_WALLIS = "kruskal_wallis"
+    PEARSON = "pearson"
+    SPEARMAN = "spearman"
+    SHAPIRO = "shapiro"
+
+
+class InputMode(Enum):
+    """How many columns a test consumes."""
+
+    ONE = "one"  # A single sample column
+    TWO = "two"  # Two sample columns (A and B)
+    MANY = "many"  # Two or more group columns
+
+
+class Alternative(Enum):
+    """Alternative hypothesis direction."""
+
+    TWO_SIDED = "two-sided"
+    LESS = "less"
+    GREATER = "greater"
+
+
+@dataclass
+class StatTestInfo:
+    """Static metadata describing a statistical test for the guided UI."""
+
+    test_type: StatTestType
+    label: str
+    input_mode: InputMode
+    # Which optional parameters the test consumes.
+    uses_alternative: bool = False
+    uses_popmean: bool = False
+    uses_equal_var: bool = False
+    description: str = ""
+    assumptions: str = ""
+
+
+# Catalog of tests grouped in a sensible order for the UI. This drives both the
+# combo box and the dynamic input/parameter widgets in the statistics panel.
+STAT_TESTS: Dict[StatTestType, StatTestInfo] = {
+    StatTestType.ONE_SAMPLE_T: StatTestInfo(
+        test_type=StatTestType.ONE_SAMPLE_T,
+        label="One-sample t-test",
+        input_mode=InputMode.ONE,
+        uses_alternative=True,
+        uses_popmean=True,
+        description="Tests whether the mean of a single sample differs from a known/expected value.",
+        assumptions="Sample is approximately normally distributed; observations are independent.",
+    ),
+    StatTestType.INDEPENDENT_T: StatTestInfo(
+        test_type=StatTestType.INDEPENDENT_T,
+        label="Independent (two-sample) t-test",
+        input_mode=InputMode.TWO,
+        uses_alternative=True,
+        uses_equal_var=True,
+        description="Compares the means of two independent groups.",
+        assumptions="Each group is approximately normal; observations are independent. "
+        "Uncheck 'equal variance' for Welch's t-test when variances differ.",
+    ),
+    StatTestType.PAIRED_T: StatTestInfo(
+        test_type=StatTestType.PAIRED_T,
+        label="Paired t-test",
+        input_mode=InputMode.TWO,
+        uses_alternative=True,
+        description="Compares two related measurements (e.g. before/after) on the same subjects.",
+        assumptions="Paired differences are approximately normal; pairs are independent.",
+    ),
+    StatTestType.MANN_WHITNEY: StatTestInfo(
+        test_type=StatTestType.MANN_WHITNEY,
+        label="Mann-Whitney U (nonparametric)",
+        input_mode=InputMode.TWO,
+        uses_alternative=True,
+        description="Nonparametric alternative to the independent t-test; compares distributions of two groups.",
+        assumptions="Observations are independent. No normality assumption required.",
+    ),
+    StatTestType.WILCOXON: StatTestInfo(
+        test_type=StatTestType.WILCOXON,
+        label="Wilcoxon signed-rank (nonparametric)",
+        input_mode=InputMode.TWO,
+        uses_alternative=True,
+        description="Nonparametric alternative to the paired t-test for two related samples.",
+        assumptions="Paired differences are symmetric. No normality assumption required.",
+    ),
+    StatTestType.ONE_WAY_ANOVA: StatTestInfo(
+        test_type=StatTestType.ONE_WAY_ANOVA,
+        label="One-way ANOVA",
+        input_mode=InputMode.MANY,
+        description="Tests whether the means of three or more groups are all equal.",
+        assumptions="Groups are approximately normal with similar variances; observations are independent.",
+    ),
+    StatTestType.KRUSKAL_WALLIS: StatTestInfo(
+        test_type=StatTestType.KRUSKAL_WALLIS,
+        label="Kruskal-Wallis (nonparametric)",
+        input_mode=InputMode.MANY,
+        description="Nonparametric alternative to one-way ANOVA; compares distributions across groups.",
+        assumptions="Observations are independent. No normality assumption required.",
+    ),
+    StatTestType.PEARSON: StatTestInfo(
+        test_type=StatTestType.PEARSON,
+        label="Pearson correlation",
+        input_mode=InputMode.TWO,
+        uses_alternative=True,
+        description="Measures the strength of a linear relationship between two variables.",
+        assumptions="Relationship is linear; both variables are approximately normal.",
+    ),
+    StatTestType.SPEARMAN: StatTestInfo(
+        test_type=StatTestType.SPEARMAN,
+        label="Spearman correlation (rank)",
+        input_mode=InputMode.TWO,
+        uses_alternative=True,
+        description="Measures the strength of a monotonic (rank-based) relationship between two variables.",
+        assumptions="Relationship is monotonic. No normality assumption required.",
+    ),
+    StatTestType.SHAPIRO: StatTestInfo(
+        test_type=StatTestType.SHAPIRO,
+        label="Shapiro-Wilk normality test",
+        input_mode=InputMode.ONE,
+        description="Tests whether a sample was drawn from a normally distributed population.",
+        assumptions="Observations are independent. Best for small-to-moderate sample sizes.",
+    ),
+}
+
+
+@dataclass
+class StatTestResult:
+    """Result of a statistical test, ready to be shown as data."""
+
+    test_type: StatTestType
+    test_name: str
+    source_columns: List[str]
+    statistic: float
+    p_value: float
+    alpha: float
+    # Ordered (metric, value) pairs shown as the results table.
+    rows: List[Tuple[str, Any]] = field(default_factory=list)
+    conclusion: str = ""
+    metadata: Dict[str, Any] = field(default_factory=dict)
+
+    @property
+    def significant(self) -> bool:
+        """Whether the result is significant at the chosen alpha level."""
+        return self.p_value is not None and self.p_value < self.alpha
+
+    def to_dataframe(self) -> pd.DataFrame:
+        """Convert the result into a tidy Metric/Value table."""
+        return pd.DataFrame(self.rows, columns=["Metric", "Value"])
+
+    def result_name(self) -> str:
+        """Generate a default name for the results dataset."""
+        cols = ", ".join(self.source_columns)
+        return f"{self.test_name} [{cols}]"

--- a/pandaplot/commands/project/dataset/statistical_test_command.py
+++ b/pandaplot/commands/project/dataset/statistical_test_command.py
@@ -1,0 +1,146 @@
+"""
+Command for running a statistical test and adding the results to the project
+as a new dataset, with undo/redo support.
+"""
+
+import uuid
+from typing import List, Optional, override
+
+from pandaplot.analysis import StatsEngine, StatTestResult, StatTestType
+from pandaplot.commands.base_command import Command
+from pandaplot.models.events.event_types import DatasetEvents
+from pandaplot.models.project.items import Dataset
+from pandaplot.models.state import AppContext, AppState
+
+
+class StatisticalTestCommand(Command):
+    """
+    Runs a statistical test on the columns of a source dataset and stores the
+    result as a new results dataset in the project.
+    """
+
+    def __init__(
+        self,
+        app_context: AppContext,
+        source_dataset_id: str,
+        test_type: StatTestType,
+        column_names: List[str],
+        alpha: float = 0.05,
+        alternative: str = "two-sided",
+        popmean: float = 0.0,
+        equal_var: bool = True,
+        result_name: Optional[str] = None,
+        folder_id: Optional[str] = None,
+    ):
+        super().__init__()
+        self.app_context = app_context
+        self.app_state: AppState = app_context.get_app_state()
+
+        self.source_dataset_id = source_dataset_id
+        self.test_type = test_type
+        self.column_names = column_names
+        self.alpha = alpha
+        self.alternative = alternative
+        self.popmean = popmean
+        self.equal_var = equal_var
+        self.result_name = result_name
+        self.folder_id = folder_id
+
+        # State for undo/redo.
+        self.result_dataset_id: Optional[str] = None
+        self.result: Optional[StatTestResult] = None
+
+    def run_test(self) -> StatTestResult:
+        """Run the test and return the result without touching the project.
+
+        Useful for previewing results in the UI before committing them.
+        """
+        source = self._get_source_dataset()
+        if source is None or source.data is None:
+            raise ValueError("Source dataset is not available.")
+
+        missing = [c for c in self.column_names if c not in source.data.columns]
+        if missing:
+            raise ValueError(f"Columns not found in dataset: {', '.join(missing)}")
+
+        columns = [source.data[c] for c in self.column_names]
+        return StatsEngine.run_test(
+            self.test_type,
+            columns,
+            alpha=self.alpha,
+            alternative=self.alternative,
+            popmean=self.popmean,
+            equal_var=self.equal_var,
+        )
+
+    @override
+    def execute(self) -> bool:
+        try:
+            self.logger.info("Executing StatisticalTestCommand (%s)", self.test_type.value)
+            if not self.app_state.has_project or not self.app_state.current_project:
+                self.logger.warning("No project loaded; cannot run statistical test.")
+                return False
+
+            project = self.app_state.current_project
+
+            self.result = self.run_test()
+
+            results_df = self.result.to_dataframe()
+            name = self.result_name or self.result.result_name()
+
+            self.result_dataset_id = str(uuid.uuid4())
+            dataset = Dataset(
+                id=self.result_dataset_id,
+                name=name,
+                data=results_df,
+                source_file=None,
+            )
+            project.add_item(dataset, parent_id=self.folder_id)
+
+            self.app_state.event_bus.emit(DatasetEvents.DATASET_CREATED, {
+                "project": project,
+                "dataset_id": self.result_dataset_id,
+                "dataset_name": name,
+                "folder_id": self.folder_id,
+                "dataset_data": dataset.data,
+            })
+
+            self.logger.info("Created results dataset '%s' (%s)", name, self.result_dataset_id)
+            return True
+
+        except Exception as e:
+            self.logger.error("Statistical test failed: %s", e, exc_info=True)
+            return False
+
+    @override
+    def undo(self) -> bool:
+        try:
+            if not self.result_dataset_id or not self.app_state.current_project:
+                return False
+            project = self.app_state.current_project
+            dataset = project.find_item(self.result_dataset_id)
+            if dataset:
+                project.remove_item(dataset)
+                self.app_state.event_bus.emit(DatasetEvents.DATASET_DELETED, {
+                    "project": project,
+                    "dataset_id": self.result_dataset_id,
+                    "dataset_name": dataset.name,
+                })
+            self.logger.info("Undone statistical test results dataset '%s'", self.result_dataset_id)
+            return True
+        except Exception as e:
+            self.logger.error("Failed to undo statistical test: %s", e, exc_info=True)
+            return False
+
+    @override
+    def redo(self) -> bool:
+        return self.execute()
+
+    def _get_source_dataset(self) -> Optional[Dataset]:
+        project = self.app_state.current_project
+        if not project:
+            return None
+        item = project.find_item(self.source_dataset_id)
+        if isinstance(item, Dataset):
+            return item
+        return None

--- a/pandaplot/gui/components/sidebar/panels/panel_setup_manager.py
+++ b/pandaplot/gui/components/sidebar/panels/panel_setup_manager.py
@@ -16,6 +16,7 @@ from pandaplot.gui.components.sidebar.panels.panel_conditions import (
     is_dataset_tab_active,
 )
 from pandaplot.gui.components.sidebar.project.project_view_panel import ProjectViewPanel
+from pandaplot.gui.components.sidebar.statistics.statistics_panel import StatisticsPanel
 from pandaplot.gui.components.sidebar.transform.transform_panel import TransformPanel
 from pandaplot.models.state.app_context import AppContext
 
@@ -34,6 +35,7 @@ class PanelSetupManager:
         self.register_panel(TransformPanel(self.app_context), "transform", "🔧", is_dataset_tab_active)
 
         self.register_panel(AnalysisPanel(self.app_context), "analysis", "📊", is_dataset_tab_active)
+        self.register_panel(StatisticsPanel(self.app_context), "statistics", "🧪", is_dataset_tab_active)
         self.register_panel(ChartPropertiesPanel(self.app_context), "chart_properties", "📈", is_chart_tab_active)
         self.register_panel(FitPanel(self.app_context), "fit", "📐", is_chart_tab_active)
 

--- a/pandaplot/gui/components/sidebar/statistics/__init__.py
+++ b/pandaplot/gui/components/sidebar/statistics/__init__.py
@@ -1,0 +1,1 @@
+"""Statistics sidebar panel package."""

--- a/pandaplot/gui/components/sidebar/statistics/statistics_panel.py
+++ b/pandaplot/gui/components/sidebar/statistics/statistics_panel.py
@@ -1,0 +1,494 @@
+"""
+Statistics panel: a guided side panel for running the most common statistical
+hypothesis tests on dataset columns and adding the results to the project as data.
+"""
+
+from typing import List, Optional, override
+
+from PySide6.QtCore import Qt
+from PySide6.QtWidgets import (
+    QAbstractItemView,
+    QCheckBox,
+    QComboBox,
+    QDoubleSpinBox,
+    QFormLayout,
+    QGroupBox,
+    QHBoxLayout,
+    QLabel,
+    QListWidget,
+    QPushButton,
+    QScrollArea,
+    QTextEdit,
+    QVBoxLayout,
+    QWidget,
+)
+
+from pandaplot.analysis import STAT_TESTS, InputMode, StatTestResult, StatTestType
+from pandaplot.commands.project.dataset.statistical_test_command import StatisticalTestCommand
+from pandaplot.gui.core.widget_extension import PWidget
+from pandaplot.models.events import DatasetEvents, DatasetOperationEvents, UIEvents
+from pandaplot.models.project.items import Dataset
+from pandaplot.models.state.app_context import AppContext
+from pandaplot.services.theme.theme_manager import ThemeManager
+
+
+class StatisticsPanel(PWidget):
+    """Side panel for guided statistical testing on dataset columns."""
+
+    def __init__(self, app_context: AppContext, parent: Optional[QWidget] = None):
+        super().__init__(app_context=app_context, parent=parent)
+        self.current_dataset: Optional[Dataset] = None
+        self.current_dataset_id: Optional[str] = None
+        self.last_result: Optional[StatTestResult] = None
+
+        self._initialize()
+
+    # ------------------------------------------------------------------
+    # UI construction
+    # ------------------------------------------------------------------
+
+    @override
+    def _init_ui(self):
+        main_layout = QVBoxLayout(self)
+        main_layout.setContentsMargins(8, 8, 8, 8)
+        main_layout.setSpacing(8)
+
+        self.title_label = QLabel("🧪 Statistical Tests")
+        main_layout.addWidget(self.title_label)
+
+        scroll_area = QScrollArea()
+        scroll_area.setWidgetResizable(True)
+        scroll_area.setHorizontalScrollBarPolicy(Qt.ScrollBarPolicy.ScrollBarAsNeeded)
+        scroll_area.setVerticalScrollBarPolicy(Qt.ScrollBarPolicy.ScrollBarAsNeeded)
+
+        content_widget = QWidget()
+        content_layout = QVBoxLayout(content_widget)
+        content_layout.setContentsMargins(4, 4, 4, 4)
+        content_layout.setSpacing(6)
+
+        self._create_test_type_section(content_layout)
+        self._create_input_section(content_layout)
+        self._create_parameters_section(content_layout)
+        self._create_results_section(content_layout)
+        self._create_action_buttons(content_layout)
+
+        content_layout.addStretch()
+        scroll_area.setWidget(content_widget)
+        main_layout.addWidget(scroll_area)
+
+        # Populate for the initially selected test.
+        self._on_test_type_changed()
+
+    def _create_test_type_section(self, layout):
+        group = QGroupBox("Test")
+        group_layout = QVBoxLayout()
+
+        form = QFormLayout()
+        self.test_type_combo = QComboBox()
+        for test_type, info in STAT_TESTS.items():
+            self.test_type_combo.addItem(info.label, test_type)
+        self.test_type_combo.currentIndexChanged.connect(self._on_test_type_changed)
+        form.addRow("Test:", self.test_type_combo)
+        group_layout.addLayout(form)
+
+        self.description_label = QLabel()
+        self.description_label.setWordWrap(True)
+        group_layout.addWidget(self.description_label)
+
+        self.assumptions_label = QLabel()
+        self.assumptions_label.setWordWrap(True)
+        group_layout.addWidget(self.assumptions_label)
+
+        group.setLayout(group_layout)
+        layout.addWidget(group)
+
+    def _create_input_section(self, layout):
+        self.input_group = QGroupBox("Data Selection")
+        self.input_layout = QFormLayout()
+        self.input_group.setLayout(self.input_layout)
+        layout.addWidget(self.input_group)
+
+    def _create_parameters_section(self, layout):
+        self.parameters_group = QGroupBox("Parameters")
+        self.parameters_layout = QFormLayout()
+        self.parameters_group.setLayout(self.parameters_layout)
+        layout.addWidget(self.parameters_group)
+
+    def _create_results_section(self, layout):
+        group = QGroupBox("Results")
+        group_layout = QVBoxLayout()
+
+        self.run_btn = QPushButton("▶ Run Test")
+        self.run_btn.clicked.connect(self.run_test)
+        group_layout.addWidget(self.run_btn)
+
+        self.results_text = QTextEdit()
+        self.results_text.setReadOnly(True)
+        self.results_text.setMinimumHeight(160)
+        self.results_text.setPlaceholderText("Run a test to see results here...")
+        group_layout.addWidget(self.results_text)
+
+        group.setLayout(group_layout)
+        layout.addWidget(group)
+
+    def _create_action_buttons(self, layout):
+        button_layout = QHBoxLayout()
+
+        self.add_btn = QPushButton("➕ Add Results to Project")
+        self.add_btn.clicked.connect(self.add_results_to_project)
+        self.add_btn.setEnabled(False)
+
+        self.clear_btn = QPushButton("🔄 Clear")
+        self.clear_btn.clicked.connect(self.clear)
+
+        button_layout.addWidget(self.add_btn)
+        button_layout.addWidget(self.clear_btn)
+        layout.addLayout(button_layout)
+
+    # ------------------------------------------------------------------
+    # Dynamic form building
+    # ------------------------------------------------------------------
+
+    def _current_test_type(self) -> StatTestType:
+        return self.test_type_combo.currentData()
+
+    def _on_test_type_changed(self):
+        test_type = self._current_test_type()
+        if test_type is None:
+            return
+        info = STAT_TESTS[test_type]
+
+        self.description_label.setText(f"ℹ️ {info.description}")
+        self.assumptions_label.setText(f"Assumptions: {info.assumptions}" if info.assumptions else "")
+        self._apply_hint_label_theme(self.description_label)
+        self._apply_hint_label_theme(self.assumptions_label)
+
+        self._build_input_widgets(info.input_mode)
+        self._build_parameter_widgets(info)
+
+        # Selecting a new test invalidates the previous result.
+        self.last_result = None
+        self.add_btn.setEnabled(False)
+
+    def _build_input_widgets(self, input_mode: InputMode):
+        self._clear_layout(self.input_layout)
+        self.column_combos: List[QComboBox] = []
+        self.group_list: Optional[QListWidget] = None
+
+        columns = self._numeric_columns()
+
+        if input_mode == InputMode.ONE:
+            combo = QComboBox()
+            combo.addItems(columns)
+            self.column_combos.append(combo)
+            self.input_layout.addRow("Sample column:", combo)
+
+        elif input_mode == InputMode.TWO:
+            combo_a = QComboBox()
+            combo_b = QComboBox()
+            combo_a.addItems(columns)
+            combo_b.addItems(columns)
+            if len(columns) >= 2:
+                combo_b.setCurrentIndex(1)
+            self.column_combos.extend([combo_a, combo_b])
+            self.input_layout.addRow("Column A:", combo_a)
+            self.input_layout.addRow("Column B:", combo_b)
+
+        else:  # MANY
+            self.group_list = QListWidget()
+            self.group_list.setSelectionMode(QAbstractItemView.SelectionMode.ExtendedSelection)
+            self.group_list.addItems(columns)
+            self.group_list.setMaximumHeight(140)
+            # Preselect first two groups as a convenience.
+            for i in range(min(2, len(columns))):
+                self.group_list.item(i).setSelected(True)
+            hint = QLabel("Select 2+ numeric group columns (Ctrl/Shift-click).")
+            self._apply_hint_label_theme(hint)
+            self.input_layout.addRow("Groups:", self.group_list)
+            self.input_layout.addRow("", hint)
+
+    def _build_parameter_widgets(self, info):
+        self._clear_layout(self.parameters_layout)
+
+        # Significance level is common to every test.
+        self.alpha_spin = QDoubleSpinBox()
+        self.alpha_spin.setDecimals(4)
+        self.alpha_spin.setRange(0.0001, 0.5)
+        self.alpha_spin.setSingleStep(0.01)
+        self.alpha_spin.setValue(0.05)
+        self.parameters_layout.addRow("Significance (α):", self.alpha_spin)
+
+        self.popmean_spin = None
+        if info.uses_popmean:
+            self.popmean_spin = QDoubleSpinBox()
+            self.popmean_spin.setDecimals(6)
+            self.popmean_spin.setRange(-1e12, 1e12)
+            self.popmean_spin.setValue(0.0)
+            self.parameters_layout.addRow("Expected mean (μ₀):", self.popmean_spin)
+
+        self.alternative_combo = None
+        if info.uses_alternative:
+            self.alternative_combo = QComboBox()
+            self.alternative_combo.addItems(["two-sided", "less", "greater"])
+            self.parameters_layout.addRow("Alternative:", self.alternative_combo)
+
+        self.equal_var_check = None
+        if info.uses_equal_var:
+            self.equal_var_check = QCheckBox("Assume equal variance (uncheck for Welch)")
+            self.equal_var_check.setChecked(True)
+            self.parameters_layout.addRow("", self.equal_var_check)
+
+    # ------------------------------------------------------------------
+    # Actions
+    # ------------------------------------------------------------------
+
+    def _selected_columns(self) -> List[str]:
+        info = STAT_TESTS[self._current_test_type()]
+        if info.input_mode == InputMode.MANY:
+            if self.group_list is None:
+                return []
+            return [item.text() for item in self.group_list.selectedItems()]
+        return [combo.currentText() for combo in self.column_combos if combo.currentText()]
+
+    def _build_command(self) -> Optional[StatisticalTestCommand]:
+        if not self.current_dataset_id:
+            self.results_text.setText("❌ No dataset selected.")
+            return None
+
+        test_type = self._current_test_type()
+        info = STAT_TESTS[test_type]
+        columns = self._selected_columns()
+
+        if info.input_mode == InputMode.MANY and len(columns) < 2:
+            self.results_text.setText("❌ Please select at least 2 group columns.")
+            return None
+        if info.input_mode == InputMode.TWO and (len(columns) < 2 or columns[0] == columns[1]):
+            self.results_text.setText("❌ Please select two different columns.")
+            return None
+        if info.input_mode == InputMode.ONE and not columns:
+            self.results_text.setText("❌ Please select a column.")
+            return None
+
+        return StatisticalTestCommand(
+            app_context=self.app_context,
+            source_dataset_id=self.current_dataset_id,
+            test_type=test_type,
+            column_names=columns,
+            alpha=self.alpha_spin.value(),
+            alternative=self.alternative_combo.currentText() if self.alternative_combo else "two-sided",
+            popmean=self.popmean_spin.value() if self.popmean_spin else 0.0,
+            equal_var=self.equal_var_check.isChecked() if self.equal_var_check else True,
+        )
+
+    def run_test(self):
+        """Run the selected test and preview results (without adding to project)."""
+        command = self._build_command()
+        if command is None:
+            return
+        try:
+            result = command.run_test()
+        except Exception as e:
+            self.last_result = None
+            self.add_btn.setEnabled(False)
+            self.results_text.setText(f"❌ Test failed: {e}")
+            return
+
+        self.last_result = result
+        self.add_btn.setEnabled(True)
+        self.results_text.setText(self._format_result(result))
+
+    def add_results_to_project(self):
+        """Run the test through the command executor and add results as a dataset."""
+        command = self._build_command()
+        if command is None:
+            return
+        executed = self.app_context.get_command_executor().execute_command(command)
+        if executed and command.result_dataset_id:
+            self.last_result = command.result
+            self.publish_event(DatasetEvents.DATASET_CREATED, {
+                "dataset_id": command.result_dataset_id,
+                "source": "statistics_panel",
+            })
+            name = command.result.result_name() if command.result else "results"
+            self.results_text.setText(
+                f"✅ Results added to project as dataset:\n'{name}'\n\n"
+                + (self._format_result(command.result) if command.result else "")
+            )
+        else:
+            self.results_text.setText("❌ Failed to add results. Please check your selection.")
+
+    def clear(self):
+        self.results_text.clear()
+        self.last_result = None
+        self.add_btn.setEnabled(False)
+
+    @staticmethod
+    def _format_result(result: StatTestResult) -> str:
+        lines = [f"{result.test_name}", "=" * 32]
+        for metric, value in result.rows:
+            if metric == "Conclusion":
+                continue
+            lines.append(f"{metric}: {value}")
+        if result.conclusion:
+            lines.append("")
+            lines.append(result.conclusion)
+        return "\n".join(lines)
+
+    # ------------------------------------------------------------------
+    # Dataset context handling
+    # ------------------------------------------------------------------
+
+    def _numeric_columns(self) -> List[str]:
+        if not self.current_dataset or self.current_dataset.data is None:
+            return []
+        import pandas as pd
+
+        df = self.current_dataset.data
+        return [str(c) for c in df.columns if pd.api.types.is_numeric_dtype(df[c])]
+
+    def _refresh_inputs(self):
+        """Rebuild the input widgets against the current dataset's columns."""
+        test_type = self._current_test_type()
+        if test_type is not None:
+            self._build_input_widgets(STAT_TESTS[test_type].input_mode)
+
+    def update_context(self, tab_widget):
+        """Update panel context from the active tab (called by sidebar wiring)."""
+        if tab_widget is not None and getattr(tab_widget, "dataset", None):
+            self.current_dataset = tab_widget.dataset
+            self.current_dataset_id = tab_widget.dataset.id
+            self.setEnabled(True)
+            self._refresh_inputs()
+        else:
+            self.current_dataset = None
+            self.current_dataset_id = None
+            self.setEnabled(False)
+
+    @override
+    def setup_event_subscriptions(self):
+        self.subscribe_to_multiple_events([
+            (UIEvents.TAB_CHANGED, self.on_tab_changed),
+            (DatasetOperationEvents.DATASET_COLUMN_ADDED, self.on_columns_changed),
+            (DatasetOperationEvents.DATASET_COLUMN_REMOVED, self.on_columns_changed),
+        ])
+
+    def on_tab_changed(self, event_data):
+        if event_data.get("tab_type") == "dataset":
+            dataset_id = event_data.get("dataset_id")
+            self.current_dataset_id = dataset_id
+            self.current_dataset = None
+            if dataset_id:
+                project = self.app_context.get_app_state().current_project
+                if project:
+                    item = project.find_item(dataset_id)
+                    if isinstance(item, Dataset):
+                        self.current_dataset = item
+            self._refresh_inputs()
+        else:
+            self.current_dataset = None
+            self.current_dataset_id = None
+            self._refresh_inputs()
+
+    def on_columns_changed(self, event_data):
+        if event_data.get("dataset_id") == self.current_dataset_id:
+            self._refresh_inputs()
+
+    # ------------------------------------------------------------------
+    # Helpers / theming
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _clear_layout(layout: QFormLayout):
+        while layout.count():
+            child = layout.takeAt(0)
+            if child.widget():
+                child.widget().deleteLater()
+
+    def _apply_hint_label_theme(self, label: QLabel):
+        theme_manager = self.app_context.get_manager(ThemeManager)
+        palette = theme_manager.get_surface_palette()
+        secondary_fg = palette.get("secondary_fg", "#666666")
+        label.setStyleSheet(f"QLabel {{ color: {secondary_fg}; font-style: italic; background-color: transparent; }}")
+
+    @override
+    def _apply_theme(self):
+        theme_manager = self.app_context.get_manager(ThemeManager)
+        palette = theme_manager.get_surface_palette()
+
+        card_bg = palette.get("card_bg", "#ffffff")
+        card_border = palette.get("card_border", "#dee2e6")
+        base_fg = palette.get("base_fg", "#333333")
+        secondary_fg = palette.get("secondary_fg", "#666666")
+        accent = palette.get("accent", "#4CAF50")
+        card_hover = palette.get("card_hover", "#e5f3ff")
+
+        self.setStyleSheet(f"""
+            StatisticsPanel {{
+                background-color: {card_bg};
+                color: {base_fg};
+            }}
+            QGroupBox {{
+                font-weight: bold;
+                font-size: 9pt;
+                color: {base_fg};
+                margin-top: 5px;
+                padding-top: 10px;
+                background-color: {card_bg};
+                border: 1px solid {card_border};
+                border-radius: 4px;
+            }}
+            QGroupBox::title {{
+                subcontrol-origin: margin;
+                left: 10px;
+                padding: 0 5px 0 5px;
+                background-color: {card_bg};
+            }}
+        """)
+
+        self.title_label.setStyleSheet(f"""
+            QLabel {{
+                font-size: 14px;
+                font-weight: bold;
+                color: {base_fg};
+                padding: 5px;
+                background-color: {card_border};
+                border-radius: 3px;
+            }}
+        """)
+
+        self.run_btn.setStyleSheet("""
+            QPushButton {
+                background-color: #3498db;
+                color: white;
+                border: none;
+                border-radius: 4px;
+                padding: 8px 16px;
+                font-weight: bold;
+            }
+            QPushButton:hover { background-color: #2980b9; }
+        """)
+
+        self.add_btn.setStyleSheet(f"""
+            QPushButton {{
+                background-color: {accent};
+                color: white;
+                border: none;
+                border-radius: 4px;
+                padding: 10px 16px;
+                font-weight: bold;
+            }}
+            QPushButton:hover {{ background-color: {card_hover}; color: {base_fg}; }}
+            QPushButton:disabled {{ background-color: {secondary_fg}; color: #999999; }}
+        """)
+
+        self.clear_btn.setStyleSheet(f"""
+            QPushButton {{
+                background-color: {secondary_fg};
+                color: white;
+                border: none;
+                border-radius: 4px;
+                padding: 10px 16px;
+                font-weight: bold;
+            }}
+            QPushButton:hover {{ background-color: #7f8c8d; }}
+        """)

--- a/pandaplot/services/fit/fit_service.py
+++ b/pandaplot/services/fit/fit_service.py
@@ -1,5 +1,7 @@
 import logging
 import re
+from dataclasses import dataclass
+
 import numpy as np
 
 from pandaplot.models.events import FitEvents

--- a/tests/analysis/test_stats_engine.py
+++ b/tests/analysis/test_stats_engine.py
@@ -1,0 +1,71 @@
+"""Tests for the statistical testing engine."""
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from pandaplot.analysis import STAT_TESTS, InputMode, StatsEngine, StatTestType
+
+
+@pytest.fixture
+def rng():
+    return np.random.default_rng(42)
+
+
+def _cols(**series):
+    return [pd.Series(v, name=k) for k, v in series.items()]
+
+
+class TestStatsEngine:
+    def test_one_sample_t_detects_difference(self, rng):
+        sample = rng.normal(10, 1, 60)
+        result = StatsEngine.run_test(StatTestType.ONE_SAMPLE_T, _cols(A=sample), popmean=5.0)
+        assert result.p_value < 0.05
+        assert result.significant
+        assert not result.to_dataframe().empty
+
+    def test_independent_t_welch(self, rng):
+        a = rng.normal(10, 1, 50)
+        b = rng.normal(13, 1, 50)
+        result = StatsEngine.run_test(StatTestType.INDEPENDENT_T, _cols(A=a, B=b), equal_var=False)
+        assert result.p_value < 0.05
+        assert any("Welch" in str(v) for _, v in result.rows)
+
+    def test_paired_t_uses_complete_pairs_only(self):
+        a = pd.Series([1.0, 2.0, 3.0, np.nan, 5.0], name="A")
+        b = pd.Series([2.0, 3.0, np.nan, 4.0, 6.0], name="B")
+        result = StatsEngine.run_test(StatTestType.PAIRED_T, [a, b])
+        # Only 3 rows have both values present.
+        n_pairs = dict(result.rows)["N pairs"]
+        assert n_pairs == 3
+
+    def test_anova_across_three_groups(self, rng):
+        result = StatsEngine.run_test(
+            StatTestType.ONE_WAY_ANOVA,
+            _cols(A=rng.normal(0, 1, 40), B=rng.normal(3, 1, 40), C=rng.normal(6, 1, 40)),
+        )
+        assert result.p_value < 0.05
+
+    def test_pearson_correlation(self):
+        x = np.arange(50, dtype=float)
+        result = StatsEngine.run_test(StatTestType.PEARSON, _cols(X=x, Y=2 * x + 1))
+        assert result.statistic == pytest.approx(1.0, abs=1e-9)
+
+    def test_shapiro_conclusion_inverted(self, rng):
+        # Clearly non-normal (uniform) data should reject normality.
+        result = StatsEngine.run_test(StatTestType.SHAPIRO, _cols(A=rng.uniform(0, 1, 300)))
+        assert "NOT normally distributed" in result.conclusion
+
+    def test_requires_enough_data(self):
+        with pytest.raises(ValueError):
+            StatsEngine.run_test(StatTestType.ONE_SAMPLE_T, _cols(A=[1.0]))
+
+    def test_every_registered_test_runs(self, rng):
+        data = {c: rng.normal(i, 1, 30) for i, c in enumerate(["A", "B", "C"])}
+        df = pd.DataFrame(data)
+        for test_type, info in STAT_TESTS.items():
+            n = {InputMode.ONE: 1, InputMode.TWO: 2, InputMode.MANY: 3}[info.input_mode]
+            cols = [df[c] for c in list(df.columns)[:n]]
+            result = StatsEngine.run_test(test_type, cols)
+            assert result.test_type == test_type
+            assert not result.to_dataframe().empty

--- a/tests/commands/project/dataset/test_statistical_test_command.py
+++ b/tests/commands/project/dataset/test_statistical_test_command.py
@@ -1,0 +1,69 @@
+"""Tests for StatisticalTestCommand."""
+
+from unittest.mock import Mock
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from pandaplot.analysis import StatTestType
+from pandaplot.commands.project.dataset.statistical_test_command import StatisticalTestCommand
+from pandaplot.models.project.items.dataset import Dataset
+from pandaplot.models.project.project import Project
+from pandaplot.models.state import AppContext, AppState
+
+
+@pytest.fixture
+def app_context_with_project():
+    rng = np.random.default_rng(7)
+    project = Project(name="P")
+    dataset = Dataset(
+        id="ds-1",
+        name="Data",
+        data=pd.DataFrame({"A": rng.normal(10, 1, 40), "B": rng.normal(13, 1, 40)}),
+    )
+    project.add_item(dataset)
+
+    app_context = Mock(spec=AppContext)
+    app_state = Mock(spec=AppState)
+    app_state.has_project = True
+    app_state.current_project = project
+    app_state.event_bus = Mock()
+    app_context.get_app_state.return_value = app_state
+    app_context.event_bus = Mock()
+    return app_context, project
+
+
+class TestStatisticalTestCommand:
+    def test_execute_adds_results_dataset(self, app_context_with_project):
+        app_context, project = app_context_with_project
+        command = StatisticalTestCommand(
+            app_context, "ds-1", StatTestType.INDEPENDENT_T, ["A", "B"], equal_var=False
+        )
+
+        assert command.execute() is True
+
+        results = project.find_item(command.result_dataset_id)
+        assert results is not None
+        assert list(results.data.columns) == ["Metric", "Value"]
+        assert command.result.significant is True
+
+    def test_undo_removes_results_dataset(self, app_context_with_project):
+        app_context, project = app_context_with_project
+        command = StatisticalTestCommand(
+            app_context, "ds-1", StatTestType.PEARSON, ["A", "B"]
+        )
+        command.execute()
+        new_id = command.result_dataset_id
+        assert project.find_item(new_id) is not None
+
+        assert command.undo() is True
+        assert project.find_item(new_id) is None
+
+    def test_missing_column_fails_gracefully(self, app_context_with_project):
+        app_context, _ = app_context_with_project
+        command = StatisticalTestCommand(
+            app_context, "ds-1", StatTestType.PEARSON, ["A", "Missing"]
+        )
+        assert command.execute() is False
+        assert command.result_dataset_id is None


### PR DESCRIPTION
Resolves #12 

Summary
Adds a Statistical Tests side panel that lets users run the most common statistical hypothesis tests on dataset columns through a guided UI, with results added back into the project as data. This complements the existing Analysis and Fit features and reuses the same panel / command / engine architecture.

What's included
New 🧪 side panel (StatisticsPanel), visible whenever a dataset tab is active. It's guided end-to-end:

Selecting a test shows a plain-language description and its statistical assumptions.
Input widgets adapt to the test (single column, two columns, or a multi-select group list).
Only the relevant parameters are shown — significance level (α), alternative hypothesis, expected mean (μ₀), and an equal-variance/Welch toggle.
Run Test previews formatted results inline; Add Results to Project commits them.
10 of the most frequently used tests (via scipy.stats):

One-sample, independent (Student & Welch), and paired t-tests
Mann-Whitney U and Wilcoxon signed-rank (nonparametric)
One-way ANOVA and Kruskal-Wallis
Pearson and Spearman correlation
Shapiro-Wilk normality