### PR TITLE
feat: excel multiple sheets import

### DIFF
--- a/pandaplot/commands/project/dataset/import_data_command.py
+++ b/pandaplot/commands/project/dataset/import_data_command.py
@@ -1,11 +1,13 @@
 import os
 import uuid
-from typing import Any, Callable, Optional, Tuple, override
+from typing import Any, Callable, List, Optional, Tuple, override
 
 import pandas as pd
+from PySide6.QtWidgets import QDialog
 
 from pandaplot.commands.base_command import Command
 from pandaplot.gui.controllers.ui_controller import UIController
+from pandaplot.gui.dialogs.select_sheets_dialog import SelectSheetsDialog
 from pandaplot.models.events.event_types import DatasetEvents
 from pandaplot.models.project.items import Dataset
 from pandaplot.models.state import AppContext, AppState
@@ -13,16 +15,16 @@ from pandaplot.services.qtasks import TaskScheduler
 
 # Delimited-text extensions handled via pandas' CSV reader.
 CSV_EXTENSIONS = {".csv", ".txt", ".tsv"}
-# Excel workbook extensions. Only the first sheet is imported today; see
-# _read_excel_file() for how multi-sheet support can be added later.
+# Excel workbook extensions. Every sheet the user selects is imported as its
+# own Dataset - see execute()'s sheet-selection step and _import_data_task().
 EXCEL_EXTENSIONS = {".xlsx", ".xls"}
 SUPPORTED_EXTENSIONS = CSV_EXTENSIONS | EXCEL_EXTENSIONS
 
 
 class ImportDataCommand(Command):
     """
-    Command to import a single data file (CSV/TSV or single-sheet Excel
-    workbook) as a dataset in the project, via one unified "Import Data" action.
+    Command to import a data file (CSV/TSV, or one or more sheets of an Excel
+    workbook) as dataset(s) in the project, via one unified "Import Data" action.
 
     Supporting a new file format only requires adding a `_read_*_file` method
     and registering its extensions in the sets above.
@@ -38,10 +40,15 @@ class ImportDataCommand(Command):
         self.folder_id = folder_id
         self.file_path = None  # Path to the data file, can be set later
         self.dataset_name = None
+        # Excel sheets to import, in workbook order. None until execute() has
+        # resolved it (auto-picked for a single-sheet workbook, or chosen by
+        # the user via SelectSheetsDialog for a multi-sheet one). Not used
+        # for CSV/TSV files.
+        self.selected_sheets: Optional[List[str]] = None
 
         # Store state for undo
-        self.dataset_id = None
-        self.imported_data = None
+        self.dataset_ids: List[str] = []
+        self.imported_datasets: List[Dataset] = []
         self.project = None
 
         # Task state
@@ -90,6 +97,34 @@ class ImportDataCommand(Command):
                 self.logger.error(error_msg)
                 return False
 
+            # For Excel workbooks, resolve which sheet(s) to import: auto-pick
+            # the only one for a single-sheet workbook, otherwise let the user
+            # choose. Cached in self.selected_sheets so redo() re-executing
+            # doesn't prompt again.
+            if extension in EXCEL_EXTENSIONS and self.selected_sheets is None:
+                try:
+                    sheet_names = pd.ExcelFile(self.file_path).sheet_names
+                except Exception as e:
+                    error_msg = f"Failed to read Excel workbook: {e}"
+                    self.ui_controller.show_error_message("Import Data Error", error_msg)
+                    self.logger.error(error_msg)
+                    return False
+
+                if not sheet_names:
+                    error_msg = "The Excel workbook contains no sheets."
+                    self.ui_controller.show_error_message("Import Data Error", error_msg)
+                    self.logger.error(error_msg)
+                    return False
+
+                if len(sheet_names) == 1:
+                    self.selected_sheets = list(sheet_names)
+                else:
+                    dialog = SelectSheetsDialog(self.app_context, list(sheet_names), parent=self.ui_controller.parent_widget)
+                    if dialog.exec() != QDialog.DialogCode.Accepted or not dialog.selected_sheets:
+                        self.logger.info("Sheet selection cancelled by user")
+                        return False
+                    self.selected_sheets = dialog.selected_sheets
+
             # Get dataset name if not provided
             self.dataset_name = os.path.splitext(os.path.basename(self.file_path))[0]
 
@@ -133,38 +168,23 @@ class ImportDataCommand(Command):
         assert last_error is not None
         raise last_error
 
-    def _read_excel_file(self, file_path: str) -> pd.DataFrame:
-        """
-        Read a single-sheet Excel workbook.
+    def _read_excel_sheets(self, file_path: str, sheet_names: List[str]) -> List[Tuple[str, pd.DataFrame]]:
+        """Read each requested sheet, returning (dataset_name, dataframe) pairs.
 
-        Only the first sheet is imported for now. To add multi-sheet import
-        later: use `pd.ExcelFile(file_path).sheet_names` to list sheets and let
-        the caller choose which one(s) to import (e.g. one Dataset per sheet).
+        A single selected sheet is named after the file (matching the
+        existing CSV/single-sheet behavior); multiple selected sheets are
+        each named "<file> - <sheet>" so they don't collide with each other
+        or with datasets imported from other files.
         """
         excel_file = pd.ExcelFile(file_path)
-        sheet_names = excel_file.sheet_names
-        if not sheet_names:
-            raise ValueError("The Excel workbook contains no sheets.")
+        base_name = self.dataset_name or os.path.splitext(os.path.basename(file_path))[0]
 
-        if len(sheet_names) > 1:
-            self.logger.info(
-                "Excel file '%s' has %d sheets; importing only the first sheet '%s'.",
-                file_path,
-                len(sheet_names),
-                sheet_names[0],
-            )
-
-        return excel_file.parse(sheet_name=0)
-
-    def _read_data_file(self, file_path: str) -> pd.DataFrame:
-        """Dispatch to the reader for the file's extension."""
-        extension = os.path.splitext(file_path)[1].lower()
-        if extension in CSV_EXTENSIONS:
-            return self._read_csv_file(file_path)
-        elif extension in EXCEL_EXTENSIONS:
-            return self._read_excel_file(file_path)
-        else:
-            raise ValueError(f"Unsupported file type '{extension}'")
+        results = []
+        for sheet_name in sheet_names:
+            df = excel_file.parse(sheet_name=sheet_name)
+            name = base_name if len(sheet_names) == 1 else f"{base_name} - {sheet_name}"
+            results.append((name, df))
+        return results
 
     def _import_data_task(self, progress_callback: Callable[[float], None], **kwargs) -> dict:
         """
@@ -175,7 +195,7 @@ class ImportDataCommand(Command):
             progress_callback: Optional callback for progress updates
 
         Returns:
-            dict: {'success': bool, 'error': str or None, 'dataset_id': str or None, 'dataset': Dataset or None}
+            dict: {'success': bool, 'error': str or None, 'datasets': List[Dataset], 'file_path': str or None}
         """
         self.logger.debug("Starting data import task")
         try:
@@ -183,49 +203,47 @@ class ImportDataCommand(Command):
                 progress_callback(0.1)  # Starting import
 
             if not self.file_path or not os.path.exists(self.file_path):
-                return {"success": False, "error": f"File not found: {self.file_path}", "dataset_id": None, "dataset": None}
+                return {"success": False, "error": f"File not found: {self.file_path}", "datasets": []}
 
             if progress_callback:
                 progress_callback(0.2)  # File validation complete
 
-            # Read the data file
+            extension = os.path.splitext(self.file_path)[1].lower()
+
+            # Read the data file into one or more (name, dataframe) pairs
             try:
-                df = self._read_data_file(self.file_path)
-                if df.empty:
-                    return {"success": False, "error": "The selected file is empty.", "dataset_id": None, "dataset": None}
-
-                # Note: Don't assign to self.imported_data here to avoid thread safety issues
-                # The DataFrame will be returned in the result payload
-
+                if extension in EXCEL_EXTENSIONS:
+                    sheet_names = self.selected_sheets or [0]
+                    frames = self._read_excel_sheets(self.file_path, sheet_names)
+                else:
+                    df = self._read_csv_file(self.file_path)
+                    name = self.dataset_name or os.path.splitext(os.path.basename(self.file_path))[0]
+                    frames = [(name, df)]
             except Exception as e:
-                return {"success": False, "error": f"Failed to read file: {str(e)}", "dataset_id": None, "dataset": None}
+                return {"success": False, "error": f"Failed to read file: {str(e)}", "datasets": []}
 
             if progress_callback:
                 progress_callback(0.6)  # File read successfully
 
-            # Get dataset name if not provided
-            if not self.dataset_name:
-                self.dataset_name = os.path.splitext(os.path.basename(self.file_path))[0]
+            # Drop empty sheets rather than failing the whole import over one blank tab
+            non_empty = [(name, df) for name, df in frames if not df.empty]
+            if not non_empty:
+                error_msg = "The selected file is empty." if len(frames) == 1 else "The selected sheet(s) contain no data."
+                return {"success": False, "error": error_msg, "datasets": []}
 
-            # Create dataset ID
-            self.dataset_id = str(uuid.uuid4())
-
-            if progress_callback:
-                progress_callback(0.8)  # Dataset metadata prepared
-
-            # Create dataset object
-            dataset = Dataset(id=self.dataset_id, name=self.dataset_name, data=df, source_file=self.file_path)
+            datasets = []
+            for name, df in non_empty:
+                dataset = Dataset(id=str(uuid.uuid4()), name=name, data=df, source_file=self.file_path)
+                datasets.append(dataset)
 
             if progress_callback:
-                progress_callback(0.9)  # Dataset object created
+                progress_callback(0.9)  # Dataset objects created
 
             self.logger.info(
-                "Successfully imported '%s' from '%s' with ID '%s' (rows=%d, cols=%d)",
-                self.dataset_name,
+                "Successfully imported %d dataset(s) from '%s' (%s)",
+                len(datasets),
                 self.file_path,
-                self.dataset_id,
-                df.shape[0],
-                df.shape[1],
+                ", ".join(f"{d.name} (rows={d.data.shape[0]}, cols={d.data.shape[1]})" for d in datasets),
             )
 
             if progress_callback:
@@ -234,19 +252,14 @@ class ImportDataCommand(Command):
             return {
                 "success": True,
                 "error": None,
-                "dataset_id": self.dataset_id,
-                "dataset": dataset,
-                "dataset_name": self.dataset_name,
+                "datasets": datasets,
                 "file_path": self.file_path,
-                "rows": df.shape[0],
-                "cols": df.shape[1],
-                "imported_data": df,  # Return DataFrame in result payload
             }
 
         except Exception as e:
             error_msg = f"Error during data import: {str(e)}"
             self.logger.error(error_msg, exc_info=True)
-            return {"success": False, "error": error_msg, "dataset_id": None, "dataset": None}
+            return {"success": False, "error": error_msg, "datasets": []}
 
     def _on_import_result(self, result: dict):
         """Handle successful completion of import task."""
@@ -254,26 +267,20 @@ class ImportDataCommand(Command):
             self.is_importing = False
 
             if result.get("success", False):
-                dataset = result.get("dataset")
-                dataset_id = result.get("dataset_id")
-                dataset_name = result.get("dataset_name")
+                datasets: List[Dataset] = result.get("datasets") or []
                 file_path = result.get("file_path")
-                rows = result.get("rows", 0)
-                cols = result.get("cols", 0)
-                imported_data = result.get("imported_data")
 
-                # Assign imported_data on main thread to avoid thread safety issues
-                self.imported_data = imported_data
+                # Assign on main thread to avoid thread safety issues
+                self.imported_datasets = datasets
 
-                if dataset and self.project:
+                if datasets and self.project:
                     # Verify that we still have a project and it's the same as when we started the import
                     if not self.app_state.has_project:
                         # Project was closed during import - abort with user message
                         self.logger.warning("Project was closed during import - aborting import operation")
                         self.ui_controller.show_warning_message(
                             "Import Cancelled",
-                            f"The project was closed during import of '{dataset_name}'. "
-                            "The import has been cancelled."
+                            "The project was closed during import. The import has been cancelled."
                         )
                         return
 
@@ -283,35 +290,45 @@ class ImportDataCommand(Command):
                         self.logger.warning("Project changed during import - aborting import operation")
                         self.ui_controller.show_warning_message(
                             "Import Cancelled",
-                            f"The project was changed during import of '{dataset_name}'. "
-                            "The import has been cancelled to prevent data inconsistency."
+                            "The project was changed during import. The import has been cancelled to prevent data inconsistency."
                         )
                         return
 
-                    # Add dataset to project
-                    self.project.add_item(dataset, parent_id=self.folder_id)
+                    # Add each dataset to the project
+                    for dataset in datasets:
+                        self.project.add_item(dataset, parent_id=self.folder_id)
+                        self.dataset_ids.append(dataset.id)
 
-                    # Emit event
-                    # TODO: migrate to item created and create data class
-                    self.app_state.event_bus.emit(
-                        DatasetEvents.DATASET_CREATED,
-                        {
-                            "project": self.project,
-                            "dataset_id": dataset_id,
-                            "dataset_name": dataset_name,
-                            "folder_id": self.folder_id,
-                            "dataset_data": dataset.data,
-                            "file_path": file_path,
-                            "dataframe": imported_data,  # Use DataFrame from result payload
-                        },
-                    )
+                        # Emit event
+                        # TODO: migrate to item created and create data class
+                        self.app_state.event_bus.emit(
+                            DatasetEvents.DATASET_CREATED,
+                            {
+                                "project": self.project,
+                                "dataset_id": dataset.id,
+                                "dataset_name": dataset.name,
+                                "folder_id": self.folder_id,
+                                "dataset_data": dataset.data,
+                                "file_path": file_path,
+                                "dataframe": dataset.data,
+                            },
+                        )
 
-                    self.logger.info("Dataset '%s' successfully added to project", dataset_name)
+                    self.logger.info("%d dataset(s) successfully added to project", len(datasets))
 
                     # Show success message to user
-                    self.ui_controller.show_info_message("Import Data", f"Successfully imported '{dataset_name}'\nRows: {rows}, Columns: {cols}")
+                    if len(datasets) == 1:
+                        d = datasets[0]
+                        self.ui_controller.show_info_message(
+                            "Import Data", f"Successfully imported '{d.name}'\nRows: {d.data.shape[0]}, Columns: {d.data.shape[1]}"
+                        )
+                    else:
+                        names = "\n".join(f"- {d.name} ({d.data.shape[0]} rows, {d.data.shape[1]} cols)" for d in datasets)
+                        self.ui_controller.show_info_message(
+                            "Import Data", f"Successfully imported {len(datasets)} sheets as datasets:\n{names}"
+                        )
                 else:
-                    error_msg = "Missing dataset or project in import result"
+                    error_msg = "Missing datasets or project in import result"
                     self.ui_controller.show_error_message("Import Failed", error_msg)
                     self.logger.error(error_msg)
             else:
@@ -361,19 +378,20 @@ class ImportDataCommand(Command):
     def undo(self):
         """Undo the import data command."""
         try:
-            if self.dataset_id and self.app_state.has_project:
+            if self.dataset_ids and self.app_state.has_project:
                 project = self.app_state.current_project
                 if project:
-                    dataset = project.find_item(self.dataset_id)
-                    if dataset:
-                        project.remove_item(dataset)
+                    for dataset_id in self.dataset_ids:
+                        dataset = project.find_item(dataset_id)
+                        if dataset:
+                            project.remove_item(dataset)
 
-                    # Emit event
-                    self.app_state.event_bus.emit(
-                        DatasetEvents.DATASET_DELETED, {"project": project, "dataset_id": self.dataset_id, "dataset_data": self.imported_data}
-                    )
+                        # Emit event
+                        self.app_state.event_bus.emit(
+                            DatasetEvents.DATASET_DELETED, {"project": project, "dataset_id": dataset_id, "dataset_data": None}
+                        )
 
-                    self.logger.info("Undone import of dataset '%s'", self.dataset_id)
+                    self.logger.info("Undone import of %d dataset(s)", len(self.dataset_ids))
 
         except Exception as e:
             error_msg = f"Failed to undo data import: {str(e)}"
@@ -384,9 +402,10 @@ class ImportDataCommand(Command):
         """Redo the import data command."""
         try:
             if not self.is_importing:
-                if self.dataset_id and self.imported_data is not None and self.app_state.has_project:
+                if self.dataset_ids and self.imported_datasets and self.app_state.has_project:
                     # We have cached data, could re-add directly or re-execute
                     # For now, re-execute to maintain consistency
+                    self.dataset_ids = []
                     return self.execute()
                 else:
                     self.logger.warning("Cannot redo: no cached import data available")

--- a/pandaplot/gui/dialogs/__init__.py
+++ b/pandaplot/gui/dialogs/__init__.py
@@ -2,6 +2,7 @@
 Dialogs package for pandaplot GUI components.
 """
 
+from pandaplot.gui.dialogs.select_sheets_dialog import SelectSheetsDialog
 from pandaplot.gui.dialogs.settings_dialog import SettingsDialog
 
-__all__ = ["SettingsDialog"]
+__all__ = ["SettingsDialog", "SelectSheetsDialog"]

--- a/pandaplot/gui/dialogs/select_sheets_dialog.py
+++ b/pandaplot/gui/dialogs/select_sheets_dialog.py
@@ -1,0 +1,121 @@
+"""Dialog for choosing which sheet(s) of a multi-sheet Excel workbook to import."""
+
+from typing import List, Optional, override
+
+from PySide6.QtWidgets import (
+    QCheckBox,
+    QDialogButtonBox,
+    QHBoxLayout,
+    QLabel,
+    QPushButton,
+    QScrollArea,
+    QVBoxLayout,
+    QWidget,
+)
+
+from pandaplot.gui.core.widget_extension import PDialog
+from pandaplot.services.theme.theme_manager import ThemeManager
+
+
+class SelectSheetsDialog(PDialog):
+    """Lets the user choose which sheet(s) of an Excel workbook to import.
+
+    Each selected sheet becomes its own Dataset. On acceptance,
+    `selected_sheets` holds the chosen sheet names in workbook order;
+    it stays None if the dialog was cancelled.
+    """
+
+    def __init__(self, app_context, sheet_names: List[str], parent=None):
+        super().__init__(app_context=app_context, parent=parent)
+        self._sheet_names = sheet_names
+        self._checkboxes: List[QCheckBox] = []
+        self.selected_sheets: Optional[List[str]] = None
+        self._initialize()
+
+    @override
+    def _init_ui(self):
+        self.setWindowTitle("Select Sheets to Import")
+        self.setModal(True)
+        self.resize(360, 420)
+        self.setMinimumSize(300, 260)
+
+        layout = QVBoxLayout(self)
+        layout.setContentsMargins(20, 20, 20, 20)
+        layout.setSpacing(10)
+
+        self.title_label = QLabel("This workbook has multiple sheets.")
+        title_font = self.title_label.font()
+        title_font.setBold(True)
+        self.title_label.setFont(title_font)
+        layout.addWidget(self.title_label)
+
+        self.subtitle_label = QLabel("Choose which sheet(s) to import as datasets:")
+        layout.addWidget(self.subtitle_label)
+
+        buttons_row = QHBoxLayout()
+        select_all_btn = QPushButton("Select All")
+        select_all_btn.clicked.connect(lambda: self._set_all_checked(True))
+        deselect_all_btn = QPushButton("Deselect All")
+        deselect_all_btn.clicked.connect(lambda: self._set_all_checked(False))
+        buttons_row.addWidget(select_all_btn)
+        buttons_row.addWidget(deselect_all_btn)
+        buttons_row.addStretch()
+        layout.addLayout(buttons_row)
+
+        scroll_area = QScrollArea()
+        scroll_area.setWidgetResizable(True)
+        list_widget = QWidget()
+        self.list_layout = QVBoxLayout(list_widget)
+        self.list_layout.setContentsMargins(0, 0, 0, 0)
+        for sheet_name in self._sheet_names:
+            checkbox = QCheckBox(sheet_name)
+            checkbox.setChecked(True)  # default to importing every sheet
+            self._checkboxes.append(checkbox)
+            self.list_layout.addWidget(checkbox)
+        self.list_layout.addStretch()
+        scroll_area.setWidget(list_widget)
+        layout.addWidget(scroll_area, 1)
+
+        self.button_box = QDialogButtonBox(QDialogButtonBox.StandardButton.Ok | QDialogButtonBox.StandardButton.Cancel)
+        self.button_box.accepted.connect(self._on_accept)
+        self.button_box.rejected.connect(self.reject)
+        layout.addWidget(self.button_box)
+
+    def _set_all_checked(self, checked: bool):
+        for checkbox in self._checkboxes:
+            checkbox.setChecked(checked)
+
+    def _on_accept(self):
+        selected = [checkbox.text() for checkbox in self._checkboxes if checkbox.isChecked()]
+        if not selected:
+            self.subtitle_label.setText("Choose which sheet(s) to import as datasets: (select at least one)")
+            return
+        self.selected_sheets = selected
+        self.accept()
+
+    @override
+    def _apply_theme(self):
+        theme_manager = self.app_context.get_manager(ThemeManager)
+        palette = theme_manager.get_surface_palette()
+
+        card_bg = palette.get("card_bg", "#f8f9fa")
+        base_fg = palette.get("base_fg", "#000000")
+        secondary_fg = palette.get("secondary_fg", "#555555")
+        card_border = palette.get("card_border", "#dee2e6")
+
+        self.setStyleSheet(f"""
+            QDialog {{
+                background-color: {card_bg};
+                color: {base_fg};
+            }}
+            QLabel {{
+                color: {base_fg};
+            }}
+            QCheckBox {{
+                color: {base_fg};
+            }}
+            QScrollArea {{
+                border: 1px solid {card_border};
+            }}
+        """)
+        self.subtitle_label.setStyleSheet(f"color: {secondary_fg};")

--- a/pandaplot/services/fit/fit_service.py
+++ b/pandaplot/services/fit/fit_service.py
@@ -1,5 +1,7 @@
 import logging
 import re
+from dataclasses import dataclass
+
 import numpy as np
 
 from pandaplot.models.events import FitEvents


### PR DESCRIPTION
Built on the existing ImportDataCommand:

[import_data_command.py]: for Excel workbooks, execute() now peeks at the sheet list (pd.ExcelFile(path).sheet_names) before dispatching the background task. A single-sheet workbook is auto-selected (no prompt, same as before). A multi-sheet workbook shows a new sheet-picker dialog. Each selected sheet becomes its own Dataset:

One selected sheet → named after the file (unchanged behavior).
Multiple selected sheets → named "<file> - <sheet>" each, so they don't collide.
Empty sheets are silently skipped rather than failing the whole import.
CSV/TSV import is completely unaffected.

New [select_sheets_dialog.py]: checkbox list of sheet names with Select All/Deselect All, following the same PDialog/theming pattern as the existing ExamplesDialog.

Undo/redo now operate over the whole batch of imported datasets (dataset_ids/imported_datasets are lists), not just one.