### PR TITLE
refactor: reference chart columns by stable id instead of cascading renames

### DIFF
--- a/pandaplot/commands/project/chart/add_series_command.py
+++ b/pandaplot/commands/project/chart/add_series_command.py
@@ -30,16 +30,30 @@ class AddSeriesCommand(Command):
             return None
         return app_state.current_project.find_item(self.chart_id)
 
+    def _resolve_column_ids(self) -> tuple[str, str]:
+        """Resolve stable column ids for this series' columns, if available."""
+        from pandaplot.models.project.items.dataset import Dataset
+        app_state = self.app_context.get_app_state()
+        project = app_state.current_project if app_state.has_project else None
+        dataset = project.find_item(self.dataset_id) if project else None
+        if not isinstance(dataset, Dataset):
+            return "", ""
+        return (dataset.get_column_id(self.x_column) or "",
+                dataset.get_column_id(self.y_column) or "")
+
     @override
     def execute(self) -> bool:
         chart = self._find_chart()
         if not chart or not isinstance(chart, Chart):
             return False
 
+        x_column_id, y_column_id = self._resolve_column_ids()
         chart.add_data_series(
             dataset_id=self.dataset_id,
             x_column=self.x_column,
             y_column=self.y_column,
+            x_column_id=x_column_id,
+            y_column_id=y_column_id,
             label=self.label,
             color=self.color,
         )

--- a/pandaplot/commands/project/chart/create_chart_command.py
+++ b/pandaplot/commands/project/chart/create_chart_command.py
@@ -90,6 +90,8 @@ class CreateChartCommand(Command):
                         dataset_id=self.dataset_id,
                         x_column=columns[0],
                         y_column=columns[1],
+                        x_column_id=dataset_obj.get_column_id(columns[0]) or "",
+                        y_column_id=dataset_obj.get_column_id(columns[1]) or "",
                         label=f"{dataset_obj.name}:{columns[1]}"
                     )
                 elif len(columns) == 1:
@@ -98,6 +100,7 @@ class CreateChartCommand(Command):
                         dataset_id=self.dataset_id,
                         x_column="",  # Empty means use index
                         y_column=columns[0],
+                        y_column_id=dataset_obj.get_column_id(columns[0]) or "",
                         label=f"{dataset_obj.name}:{columns[0]}"
                     )
 

--- a/pandaplot/commands/project/dataset/delete_columns_command.py
+++ b/pandaplot/commands/project/dataset/delete_columns_command.py
@@ -181,6 +181,18 @@ class DeleteColumnsCommand(Command):
         if not self.project:
             return []
         column_set = set(column_names)
+        # Resolve the ids of the columns being deleted so references anchored by
+        # id are matched even if their stored name is stale after a rename.
+        dataset = self.dataset if self.dataset is not None else self.project.find_item(self.dataset_id)
+        id_set = set()
+        if isinstance(dataset, Dataset):
+            id_set = {cid for name, cid in dataset.column_ids.items() if name in column_set}
+
+        def refs_deleted(column_id: str, name: str) -> bool:
+            if column_id and column_id in id_set:
+                return True
+            return name in column_set
+
         matches: List[Tuple[Chart, List[int], List[int]]] = []
         for item in self.project.get_all_items():
             if not isinstance(item, Chart):
@@ -188,12 +200,14 @@ class DeleteColumnsCommand(Command):
             series_idx = [
                 i for i, series in enumerate(item.data_series)
                 if series.dataset_id == self.dataset_id
-                and (series.x_column in column_set or series.y_column in column_set)
+                and (refs_deleted(series.x_column_id, series.x_column)
+                     or refs_deleted(series.y_column_id, series.y_column))
             ]
             fit_idx = [
                 i for i, fit in enumerate(item.fit_data)
                 if fit.source_dataset_id == self.dataset_id
-                and (fit.source_x_column in column_set or fit.source_y_column in column_set)
+                and (refs_deleted(fit.source_x_column_id, fit.source_x_column)
+                     or refs_deleted(fit.source_y_column_id, fit.source_y_column))
             ]
             if series_idx or fit_idx:
                 matches.append((item, series_idx, fit_idx))

--- a/pandaplot/commands/project/dataset/rename_column_command.py
+++ b/pandaplot/commands/project/dataset/rename_column_command.py
@@ -7,15 +7,19 @@ from pandaplot.gui.controllers.ui_controller import UIController
 from pandaplot.models.events.event_data import DatasetColumnRenamedData
 from pandaplot.models.events.event_types import ChartEvents, DatasetOperationEvents
 from pandaplot.models.project.items import Chart, Dataset
+from pandaplot.models.project.items.chart import sync_fit_column_ids, sync_series_column_ids
 from pandaplot.models.state.app_context import AppContext
 from pandaplot.models.state.app_state import AppState
 
 
 class RenameColumnCommand(Command):
-    """Rename a dataset column and update chart/fit references to it.
+    """Rename a dataset column, keeping chart/fit references valid via column id.
 
-    The DataFrame rename and the reference cascade are one undoable step;
-    series/fit labels are user-editable text and are never modified.
+    Charts/fits reference columns by stable id, so a rename only remaps the
+    column's name on the owning dataset — series are never rewritten. Any legacy
+    reference that still lacks an id is backfilled (id only, not name) before the
+    rename so it stays anchored. Charts using the column are re-emitted so their
+    displayed labels refresh. Series/fit labels are user-editable and untouched.
     """
 
     def __init__(self, app_context: AppContext, dataset_id: str,
@@ -78,13 +82,15 @@ class RenameColumnCommand(Command):
             return False
 
     def _apply_rename(self, from_name: str, to_name: str) -> None:
-        """Rename the DataFrame column, cascade references, emit events."""
+        """Remap the column's name (keeping its id), then emit events."""
         if self.dataset is None or self.dataset.data is None:
             return
-        self.dataset.data.rename(columns={from_name: to_name}, inplace=True)
-        self.dataset.update_modified_time()
 
-        affected_charts = self._update_chart_references(from_name, to_name)
+        # Anchor any legacy references (id-only, never the name) while the old
+        # name still resolves, then remap the column's name on the dataset.
+        affected_charts = self._anchor_and_find_affected(from_name)
+        self.dataset.rename_column(from_name, to_name)
+        self.dataset.update_modified_time()
 
         self.app_context.event_bus.emit(
             DatasetOperationEvents.DATASET_COLUMN_RENAMED,
@@ -95,41 +101,41 @@ class RenameColumnCommand(Command):
                 new_name=to_name,
             ).to_dict())
         for chart in affected_charts:
+            chart.update_modified_time()
             self.app_context.event_bus.emit(ChartEvents.CHART_UPDATED, {
                 "chart_id": chart.id,
                 "chart": chart,
             })
 
-    def _update_chart_references(self, from_name: str, to_name: str) -> List[Chart]:
-        """Point series/fits of this dataset at the new name; return affected charts."""
+    def _anchor_and_find_affected(self, from_name: str) -> List[Chart]:
+        """Backfill column ids for references to this column; return affected charts.
+
+        References are matched by stable id (following prior renames) or by the
+        current name for legacy references. Matching legacy references are anchored
+        to the column's id so future renames need no walk at all.
+        """
         project = self.app_state.current_project
-        if not project:
+        if self.dataset is None or not project:
             return []
+        column_id = self.dataset.get_column_id(from_name)
         affected: List[Chart] = []
         for item in project.get_all_items():
             if not isinstance(item, Chart):
                 continue
-            changed = False
+            uses = False
             for series in item.data_series:
                 if series.dataset_id != self.dataset_id:
                     continue
-                if series.x_column == from_name:
-                    series.x_column = to_name
-                    changed = True
-                if series.y_column == from_name:
-                    series.y_column = to_name
-                    changed = True
+                sync_series_column_ids(series, self.dataset)
+                if column_id in (series.x_column_id, series.y_column_id):
+                    uses = True
             for fit in item.fit_data:
                 if fit.source_dataset_id != self.dataset_id:
                     continue
-                if fit.source_x_column == from_name:
-                    fit.source_x_column = to_name
-                    changed = True
-                if fit.source_y_column == from_name:
-                    fit.source_y_column = to_name
-                    changed = True
-            if changed:
-                item.update_modified_time()
+                sync_fit_column_ids(fit, self.dataset)
+                if column_id in (fit.source_x_column_id, fit.source_y_column_id):
+                    uses = True
+            if uses:
                 affected.append(item)
         return affected
 

--- a/pandaplot/gui/components/sidebar/chart/chart_properties_panel.py
+++ b/pandaplot/gui/components/sidebar/chart/chart_properties_panel.py
@@ -1047,6 +1047,10 @@ class ChartPropertiesPanel(PWidget):
                 series.dataset_id = self.dataset_combo.currentData()
             series.x_column = self.x_column_combo.currentText()
             series.y_column = self.y_column_combo.currentText()
+            # Re-anchor the stable column ids to the freshly picked columns.
+            series.x_column_id = ""
+            series.y_column_id = ""
+            self._sync_series_column_ids(series)
             series.y_axis = self.series_y_axis_combo.currentData() or "primary"
         else:
             # Fit data: columns/dataset not editable, ignore
@@ -1290,12 +1294,21 @@ class ChartPropertiesPanel(PWidget):
             # don't linger.
             self._populate_column_combos(series.dataset_id)
 
-            # Set columns
-            x_index = self.x_column_combo.findText(series.x_column)
+            # Set columns, resolving the current names via stable column id
+            # (the stored x_column/y_column may be stale after a rename).
+            from pandaplot.models.project.items.dataset import resolve_column_name
+            dataset = self.current_project.find_item(series.dataset_id) if self.current_project else None
+            if isinstance(dataset, Dataset):
+                x_name = resolve_column_name(dataset, series.x_column_id, series.x_column)
+                y_name = resolve_column_name(dataset, series.y_column_id, series.y_column)
+            else:
+                x_name, y_name = series.x_column, series.y_column
+
+            x_index = self.x_column_combo.findText(x_name)
             if x_index >= 0:
                 self.x_column_combo.setCurrentIndex(x_index)
 
-            y_index = self.y_column_combo.findText(series.y_column)
+            y_index = self.y_column_combo.findText(y_name)
             if y_index >= 0:
                 self.y_column_combo.setCurrentIndex(y_index)
 
@@ -1474,6 +1487,15 @@ class ChartPropertiesPanel(PWidget):
                     self.dataset_combo.addItem(item.name, item.id)
                     self.datasets.append(item)
     
+    def _sync_series_column_ids(self, series):
+        """Anchor a series' stable column ids to its current column names."""
+        from pandaplot.models.project.items.chart import sync_series_column_ids
+        if not self.current_project:
+            return
+        dataset = self.current_project.find_item(series.dataset_id)
+        if isinstance(dataset, Dataset):
+            sync_series_column_ids(series, dataset)
+
     def _populate_column_combos(self, dataset_id):
         """Fill the x/y column combos with the columns of the given dataset.
 
@@ -1803,10 +1825,15 @@ class ChartPropertiesPanel(PWidget):
             y_column = self.y_column_combo.currentText()
             
             if dataset_id and x_column and y_column:
+                dataset = self.current_project.find_item(dataset_id) if self.current_project else None
+                x_column_id = dataset.get_column_id(x_column) or "" if isinstance(dataset, Dataset) else ""
+                y_column_id = dataset.get_column_id(y_column) or "" if isinstance(dataset, Dataset) else ""
                 chart.add_data_series(
                     dataset_id=dataset_id,
                     x_column=x_column,
                     y_column=y_column,
+                    x_column_id=x_column_id,
+                    y_column_id=y_column_id,
                     color=self.line_color_button.get_color(),
                     line_width=self.line_width_spin.value(),
                     marker_size=self.marker_size_spin.value(),

--- a/pandaplot/gui/components/sidebar/fit/fit_panel.py
+++ b/pandaplot/gui/components/sidebar/fit/fit_panel.py
@@ -629,12 +629,21 @@ class FitPanel(PWidget):
                     self.dataset_combo.setCurrentIndex(i)
                     break
             
-            # Set columns
-            x_index = self.x_column_combo.findText(first_series.x_column)
+            # Set columns, resolving current names via stable column id
+            # (stored names may be stale after a rename).
+            from pandaplot.models.project.items.dataset import resolve_column_name
+            dataset = self.current_project.find_item(first_series.dataset_id) if self.current_project else None
+            if isinstance(dataset, Dataset):
+                x_name = resolve_column_name(dataset, first_series.x_column_id, first_series.x_column)
+                y_name = resolve_column_name(dataset, first_series.y_column_id, first_series.y_column)
+            else:
+                x_name, y_name = first_series.x_column, first_series.y_column
+
+            x_index = self.x_column_combo.findText(x_name)
             if x_index >= 0:
                 self.x_column_combo.setCurrentIndex(x_index)
-            
-            y_index = self.y_column_combo.findText(first_series.y_column)
+
+            y_index = self.y_column_combo.findText(y_name)
             if y_index >= 0:
                 self.y_column_combo.setCurrentIndex(y_index)
             

--- a/pandaplot/gui/components/tabs/chart/chart_editor.py
+++ b/pandaplot/gui/components/tabs/chart/chart_editor.py
@@ -68,6 +68,17 @@ def apply_axis_ticks(axis, mode, count, step, fmt, custom_fmt):
         axis.set_major_formatter(ScalarFormatter())
 
 
+def _same_column(id_a, name_a, id_b, name_b):
+    """Whether two column references point at the same column.
+
+    Compares by stable id when both sides have one; otherwise falls back to
+    comparing names (for references that predate column ids).
+    """
+    if id_a and id_b:
+        return id_a == id_b
+    return name_a == name_b
+
+
 def resolve_series_data(project, series, chart_type=None):
     """Resolve a DataSeries against the project's datasets.
 
@@ -76,7 +87,8 @@ def resolve_series_data(project, series, chart_type=None):
     "plot against the DataFrame index". Histograms only ever plot
     y_column, so a stale/unused x_column is ignored when chart_type == "hist".
     """
-    from pandaplot.models.project.items.dataset import Dataset
+    from pandaplot.models.project.items.chart import sync_series_column_ids
+    from pandaplot.models.project.items.dataset import Dataset, resolve_column_name
 
     if project is None:
         return None, None, "no project loaded"
@@ -85,21 +97,28 @@ def resolve_series_data(project, series, chart_type=None):
     if not isinstance(dataset, Dataset) or dataset.data is None:
         return None, None, f"dataset '{series.dataset_id}' not found"
 
+    # Reference columns by stable id; renames are followed automatically.
+    # Lazily backfill ids for series that predate them (e.g. loaded projects).
+    if not (series.x_column_id and series.y_column_id):
+        sync_series_column_ids(series, dataset)
+
     df = dataset.data
-    if not series.y_column:
+    y_column = resolve_column_name(dataset, series.y_column_id, series.y_column)
+    if not y_column:
         return None, None, "no Y column configured"
 
     needs_x_column = chart_type != "hist"
-    x_column = series.x_column if needs_x_column else None
+    x_column = (resolve_column_name(dataset, series.x_column_id, series.x_column)
+                if needs_x_column else None)
 
-    missing = [c for c in (x_column, series.y_column)
+    missing = [c for c in (x_column, y_column)
                if c and c not in df.columns]
     if missing:
         cols = ", ".join(f"'{c}'" for c in missing)
         return None, None, f"column {cols} not found in '{dataset.name}'"
 
     x_data = df[x_column] if x_column else df.index
-    return x_data, df[series.y_column], None
+    return x_data, df[y_column], None
 
 
 class ChartEditorWidget(PWidget):
@@ -547,8 +566,10 @@ class ChartEditorWidget(PWidget):
                             for series in self.chart.data_series:
                                 if (series.y_axis == "secondary"
                                         and series.dataset_id == fit.source_dataset_id
-                                        and series.x_column == fit.source_x_column
-                                        and series.y_column == fit.source_y_column):
+                                        and _same_column(series.x_column_id, series.x_column,
+                                                         fit.source_x_column_id, fit.source_x_column)
+                                        and _same_column(series.y_column_id, series.y_column,
+                                                         fit.source_y_column_id, fit.source_y_column)):
                                     fit_axes = self.chart_canvas.axes2
                                     break
 

--- a/pandaplot/gui/components/tabs/chart/chart_tab.py
+++ b/pandaplot/gui/components/tabs/chart/chart_tab.py
@@ -13,7 +13,7 @@ from pandaplot.gui.components.tabs.chart.chart_editor import ChartEditorWidget
 from pandaplot.gui.core.widget_extension import PWidget
 from pandaplot.models.events import ChartEvents, FitEvents, UIEvents
 from pandaplot.models.events.event_types import ProjectEvents
-from pandaplot.models.project.items import Chart
+from pandaplot.models.project.items import Chart, Dataset
 from pandaplot.models.state.app_context import AppContext
 
 # Maps a short fit-type name to its chart color. `fit_type` from the fit panel is a
@@ -140,10 +140,20 @@ class ChartTab(PWidget):
             fit_params = fit_results.params
             fit_stats = {"r_squared": fit_results.r_squared}
 
+            # Resolve stable column ids so the fit follows column renames.
+            source_x_column_id = source_y_column_id = ""
+            project = self.app_context.app_state.current_project
+            source_dataset = project.find_item(source_dataset_id) if project else None
+            if isinstance(source_dataset, Dataset):
+                source_x_column_id = source_dataset.get_column_id(source_x_column) or ""
+                source_y_column_id = source_dataset.get_column_id(source_y_column) or ""
+
             self.chart.add_fit_data(
                 source_dataset_id=source_dataset_id,
                 source_x_column=source_x_column,
                 source_y_column=source_y_column,
+                source_x_column_id=source_x_column_id,
+                source_y_column_id=source_y_column_id,
                 fit_type=fit_type,
                 x_data=x_fit,
                 y_data=y_fit,

--- a/pandaplot/models/project/items/chart.py
+++ b/pandaplot/models/project/items/chart.py
@@ -21,10 +21,18 @@ class YAxis(StrEnum):
 
 @dataclass
 class DataSeries:
-    """Represents a single data series in a chart."""
+    """Represents a single data series in a chart.
+
+    Columns are referenced by stable id (``x_column_id`` / ``y_column_id``) which
+    survives column renames. ``x_column`` / ``y_column`` hold the name at creation
+    time and are used only as a fallback for references that predate column ids;
+    the current name is always resolved from the owning dataset at use-time.
+    """
     dataset_id: str
     x_column: str
     y_column: str
+    x_column_id: str = ""
+    y_column_id: str = ""
     label: str = ""
     color: str = "#1f77b4"
     marker_color: str = ""
@@ -63,6 +71,9 @@ class FitData:
     fit_stats: Optional[Dict[str, Any]] = None
     confidence_lower: np.ndarray | None = None
     confidence_upper: np.ndarray | None = None
+    # Stable column ids (see DataSeries); source_x/y_column are the fallback name.
+    source_x_column_id: str = ""
+    source_y_column_id: str = ""
 
     def __post_init__(self):
         if self.fit_params is None:
@@ -154,13 +165,16 @@ class Chart(Item):
         self.chart_type = chart_type
         self.update_modified_time()
     
-    def add_data_series(self, dataset_id: str, x_column: str, y_column: str, 
-                       label: str = "", **kwargs) -> DataSeries:
+    def add_data_series(self, dataset_id: str, x_column: str, y_column: str,
+                       label: str = "", x_column_id: str = "", y_column_id: str = "",
+                       **kwargs) -> DataSeries:
         """Add a new data series to the chart."""
         series = DataSeries(
             dataset_id=dataset_id,
             x_column=x_column,
             y_column=y_column,
+            x_column_id=x_column_id,
+            y_column_id=y_column_id,
             label=label or f"{dataset_id}:{y_column}",
             **kwargs
         )
@@ -197,17 +211,20 @@ class Chart(Item):
         """Get all unique dataset IDs used in this chart."""
         return list(set(series.dataset_id for series in self.data_series))
     
-    def add_fit_data(self, source_dataset_id: str, source_x_column: str, 
-                    source_y_column: str, fit_type: str, x_data: np.ndarray, 
-                    y_data: np.ndarray, label: str = "", **kwargs) -> FitData:
+    def add_fit_data(self, source_dataset_id: str, source_x_column: str,
+                    source_y_column: str, fit_type: str, x_data: np.ndarray,
+                    y_data: np.ndarray, label: str = "", source_x_column_id: str = "",
+                    source_y_column_id: str = "", **kwargs) -> FitData:
         """Add fit data to the chart."""
         if not label:
             label = f"{fit_type.title()} Fit for {source_dataset_id}:{source_y_column}"
-        
+
         fit = FitData(
             source_dataset_id=source_dataset_id,
             source_x_column=source_x_column,
             source_y_column=source_y_column,
+            source_x_column_id=source_x_column_id,
+            source_y_column_id=source_y_column_id,
             fit_type=fit_type,
             x_data=x_data,
             y_data=y_data,
@@ -316,6 +333,8 @@ class Chart(Item):
                     "dataset_id": series.dataset_id,
                     "x_column": series.x_column,
                     "y_column": series.y_column,
+                    "x_column_id": series.x_column_id,
+                    "y_column_id": series.y_column_id,
                     "label": series.label,
                     "color": series.color,
                     "marker_color": series.marker_color,
@@ -334,6 +353,8 @@ class Chart(Item):
                     "source_dataset_id": fit.source_dataset_id,
                     "source_x_column": fit.source_x_column,
                     "source_y_column": fit.source_y_column,
+                    "source_x_column_id": fit.source_x_column_id,
+                    "source_y_column_id": fit.source_y_column_id,
                     "fit_type": fit.fit_type,
                     "x_data": fit.x_data.tolist(),
                     "y_data": fit.y_data.tolist(),
@@ -378,6 +399,8 @@ class Chart(Item):
                 dataset_id=series_dict["dataset_id"],
                 x_column=series_dict["x_column"],
                 y_column=series_dict["y_column"],
+                x_column_id=series_dict.get("x_column_id", ""),
+                y_column_id=series_dict.get("y_column_id", ""),
                 label=series_dict.get("label", ""),
                 color=series_dict.get("color", "#1f77b4"),
                 marker_color=series_dict.get("marker_color", ""),
@@ -399,6 +422,8 @@ class Chart(Item):
                 source_dataset_id=fit_dict["source_dataset_id"],
                 source_x_column=fit_dict["source_x_column"],
                 source_y_column=fit_dict["source_y_column"],
+                source_x_column_id=fit_dict.get("source_x_column_id", ""),
+                source_y_column_id=fit_dict.get("source_y_column_id", ""),
                 fit_type=fit_dict["fit_type"],
                 x_data=np.array(fit_dict["x_data"]),
                 y_data=np.array(fit_dict["y_data"]),
@@ -417,6 +442,49 @@ class Chart(Item):
             chart._init_default_config()
 
         return chart
+
+
+def sync_series_column_ids(series: DataSeries, dataset) -> None:
+    """Fill a series' column ids from its current column names.
+
+    Resolves ``x_column`` / ``y_column`` against ``dataset`` and stores the
+    stable ids. Only assigns ids that resolve, so a stale name (e.g. after a
+    rename that the series predates) never clobbers an already-valid id.
+    """
+    if dataset is None:
+        return
+    xid = dataset.get_column_id(series.x_column)
+    if xid:
+        series.x_column_id = xid
+    yid = dataset.get_column_id(series.y_column)
+    if yid:
+        series.y_column_id = yid
+
+
+def sync_fit_column_ids(fit: FitData, dataset) -> None:
+    """Fill fit data's source column ids from its current column names."""
+    if dataset is None:
+        return
+    xid = dataset.get_column_id(fit.source_x_column)
+    if xid:
+        fit.source_x_column_id = xid
+    yid = dataset.get_column_id(fit.source_y_column)
+    if yid:
+        fit.source_y_column_id = yid
+
+
+def backfill_chart_column_ids(chart: "Chart", resolve_dataset) -> None:
+    """Assign column ids to every series/fit of a chart that lacks them.
+
+    ``resolve_dataset`` maps a dataset id to its Dataset (or None). Used at
+    project load time to migrate charts saved before column ids existed.
+    """
+    for series in chart.data_series:
+        if not (series.x_column_id and series.y_column_id):
+            sync_series_column_ids(series, resolve_dataset(series.dataset_id))
+    for fit in chart.fit_data:
+        if not (fit.source_x_column_id and fit.source_y_column_id):
+            sync_fit_column_ids(fit, resolve_dataset(fit.source_dataset_id))
 
 
 def snapshot_chart_state(chart: "Chart") -> Dict[str, Any]:

--- a/pandaplot/models/project/items/dataset.py
+++ b/pandaplot/models/project/items/dataset.py
@@ -2,6 +2,7 @@
 Dataset model for managing data table items in the project.
 """
 
+import uuid
 from datetime import datetime
 from typing import Any, Dict, Optional
 
@@ -13,50 +14,123 @@ from pandaplot.models.project.items.item import Item
 class Dataset(Item):
     """
     Represents a dataset item in the project.
-    
+
     A dataset contains tabular data (typically from CSV or other data sources).
     It's part of the hierarchical project structure.
+
+    Each column also gets a stable id (independent of its display name) so that
+    charts/fits can reference a column by id and survive renames without having
+    their stored column names rewritten. The id<->name mapping lives here, on
+    the dataset that owns the column, and is kept in sync with ``data.columns``.
     """
-    
-    def __init__(self, id: Optional[str] = None, name: str = "", 
-                 data: Optional[pd.DataFrame] = None, source_file: Optional[str] = None):
+
+    def __init__(self, id: Optional[str] = None, name: str = "",
+                 data: Optional[pd.DataFrame] = None, source_file: Optional[str] = None,
+                 column_ids: Optional[Dict[str, str]] = None):
         super().__init__(id, name)
-        
+
         # Set dataset-specific attributes
         self.data: pd.DataFrame = data if data is not None else pd.DataFrame()
         self.source_file: Optional[str] = source_file
-    
+        # Maps current column name -> stable column id.
+        self.column_ids: Dict[str, str] = dict(column_ids) if column_ids else {}
+        self.ensure_column_ids()
+
     def set_data(self, data: pd.DataFrame) -> None:
         """Set the dataset data and update metadata."""
         self.data = data
+        self.ensure_column_ids()
         self.update_modified_time()
-    
+
+    # -- Column id management -------------------------------------------------
+
+    def ensure_column_ids(self) -> None:
+        """Sync ``column_ids`` with the current DataFrame columns.
+
+        Assigns a new stable id to any column that lacks one and drops entries
+        for columns that no longer exist. Safe to call repeatedly.
+        """
+        if self.data is None:
+            return
+        current = [str(c) for c in self.data.columns]
+        current_set = set(current)
+        # Drop ids for columns that are gone.
+        for name in list(self.column_ids.keys()):
+            if name not in current_set:
+                del self.column_ids[name]
+        # Assign ids for new columns.
+        for name in current:
+            if name not in self.column_ids:
+                self.column_ids[name] = uuid.uuid4().hex
+
+    def get_column_id(self, name: str) -> Optional[str]:
+        """Return the stable id for a column name, or None if unknown."""
+        if not name:
+            return None
+        return self.column_ids.get(name)
+
+    def get_column_name(self, column_id: str) -> Optional[str]:
+        """Return the current name for a column id, or None if unknown."""
+        if not column_id:
+            return None
+        for name, cid in self.column_ids.items():
+            if cid == column_id:
+                return name
+        return None
+
+    def rename_column(self, old_name: str, new_name: str) -> Optional[str]:
+        """Rename a column in the DataFrame and remap its id.
+
+        The column keeps its stable id, so references by id stay valid without
+        being rewritten. Returns the column id, or None if the column is unknown.
+        """
+        if self.data is None or old_name not in self.column_ids:
+            return None
+        self.data.rename(columns={old_name: new_name}, inplace=True)
+        column_id = self.column_ids.pop(old_name)
+        self.column_ids[new_name] = column_id
+        return column_id
+
     def to_dict(self) -> Dict[str, Any]:
         """Convert dataset to dictionary for serialization."""
         data = super().to_dict()
         data.update({
             "source_file": self.source_file,
-            "has_data": self.data is not None
+            "has_data": self.data is not None,
+            "column_ids": self.column_ids,
         })
-        
+
         # TODO: serialization of dataframe
         # Note: We don't serialize the actual DataFrame data here
         # Data should be stored separately or reconstructed from source
         return data
-    
+
     @classmethod
     def from_dict(cls, data: Dict[str, Any]) -> "Dataset":
         """Create dataset from dictionary."""
         dataset = cls(
             id=data.get("id"),
             name=data.get("name", ""),
-            source_file=data.get("source_file")
+            source_file=data.get("source_file"),
+            column_ids=data.get("column_ids"),
         )
-        
+
         # Set inherited attributes
         dataset.parent_id = data.get("parent_id")
         dataset.created_at = data.get("created_at", datetime.now().isoformat())
         dataset.modified_at = data.get("modified_at", dataset.created_at)
-        
+
         return dataset
-        
+
+
+def resolve_column_name(dataset: "Dataset", column_id: str, fallback_name: str) -> str:
+    """Resolve a column reference to its current name.
+
+    Prefers the stable ``column_id`` (following renames automatically) and
+    falls back to ``fallback_name`` for references that predate column ids.
+    """
+    if column_id:
+        name = dataset.get_column_name(column_id)
+        if name is not None:
+            return name
+    return fallback_name

--- a/pandaplot/services/fit/fit_service.py
+++ b/pandaplot/services/fit/fit_service.py
@@ -1,5 +1,7 @@
 import logging
 import re
+from dataclasses import dataclass
+
 import numpy as np
 
 from pandaplot.models.events import FitEvents

--- a/pandaplot/storage/dataset_data_manager.py
+++ b/pandaplot/storage/dataset_data_manager.py
@@ -40,7 +40,8 @@ class DatasetDataManager(ItemDataManager[Dataset]):
                 "modified_at": item.modified_at,
                 "metadata": item.metadata,
                 "source_file": item.source_file,
-                "has_data": item.data is not None
+                "has_data": item.data is not None,
+                "column_ids": item.column_ids,
             }
             
             self.logger.debug("Saving dataset metadata for '%s'", item.name)
@@ -95,7 +96,8 @@ class DatasetDataManager(ItemDataManager[Dataset]):
                 id=dataset_id,
                 name=dataset_name,
                 data=data,
-                source_file=metadata.get("source_file")
+                source_file=metadata.get("source_file"),
+                column_ids=metadata.get("column_ids"),
             )
             
             self.logger.info("Successfully loaded dataset '%s' (ID: %s)", dataset_name, dataset_id)

--- a/pandaplot/storage/project_data_manager.py
+++ b/pandaplot/storage/project_data_manager.py
@@ -68,7 +68,26 @@ class ProjectDataManager:
         project_root = project_dict.get("root", {})
         project.root.id = project_root.get("id", project.root.id)
         self._add_items_to_project(project, items, project_root.get("items", []))
+        self._backfill_column_ids(project)
         return project
+
+    def _backfill_column_ids(self, project: Project) -> None:
+        """Anchor chart/fit column references to stable ids after load.
+
+        Projects saved before column ids existed reference columns only by name;
+        resolve those against the owning datasets so future renames don't need to
+        rewrite series. New/already-anchored references are left untouched.
+        """
+        from pandaplot.models.project.items.chart import Chart, backfill_chart_column_ids
+        from pandaplot.models.project.items.dataset import Dataset
+
+        def resolve_dataset(dataset_id):
+            found = project.find_item(dataset_id)
+            return found if isinstance(found, Dataset) else None
+
+        for item in project.get_all_items():
+            if isinstance(item, Chart):
+                backfill_chart_column_ids(item, resolve_dataset)
 
     def _load_item(self, item_id: str, info, zip_file) -> Item | None:
         try:

--- a/tests/commands/project/dataset/test_rename_column_command.py
+++ b/tests/commands/project/dataset/test_rename_column_command.py
@@ -1,4 +1,9 @@
-"""Tests for RenameColumnCommand (DataFrame rename + chart-reference cascade)."""
+"""Tests for RenameColumnCommand.
+
+Columns are referenced by stable id, so a rename remaps the column's name on the
+owning dataset without rewriting the stored column names on series/fits. The
+resolved column (id -> current name) follows the rename automatically.
+"""
 
 from unittest.mock import Mock
 
@@ -10,6 +15,7 @@ from pandaplot.commands.project.dataset.rename_column_command import RenameColum
 from pandaplot.models.events.event_types import ChartEvents, DatasetOperationEvents
 from pandaplot.models.project import Project
 from pandaplot.models.project.items import Chart, Dataset
+from pandaplot.models.project.items.dataset import resolve_column_name
 
 
 @pytest.fixture
@@ -21,14 +27,22 @@ def env():
     project.add_item(other)
 
     chart = Chart(name="c")
-    chart.add_data_series(dataset.id, "a", "b", label="s1")
-    chart.add_data_series(other.id, "a", "a", label="s2")  # other dataset: must not change
+    chart.add_data_series(dataset.id, "a", "b", label="s1",
+                          x_column_id=dataset.get_column_id("a"),
+                          y_column_id=dataset.get_column_id("b"))
+    chart.add_data_series(other.id, "a", "a", label="s2",  # other dataset: must not change
+                          x_column_id=other.get_column_id("a"),
+                          y_column_id=other.get_column_id("a"))
     chart.add_fit_data(dataset.id, "a", "b", "Linear",
-                       np.array([1.0]), np.array([2.0]))
+                       np.array([1.0]), np.array([2.0]),
+                       source_x_column_id=dataset.get_column_id("a"),
+                       source_y_column_id=dataset.get_column_id("b"))
     project.add_item(chart)
 
     untouched_chart = Chart(name="c2")
-    untouched_chart.add_data_series(other.id, "a", "a", label="s3")
+    untouched_chart.add_data_series(other.id, "a", "a", label="s3",
+                                    x_column_id=other.get_column_id("a"),
+                                    y_column_id=other.get_column_id("a"))
     project.add_item(untouched_chart)
 
     app_state = Mock()
@@ -46,19 +60,40 @@ def _chart_updated_calls(app_context):
             if c.args[0] == ChartEvents.CHART_UPDATED]
 
 
-def test_rename_updates_dataframe_and_matching_references(env):
+def _resolved(dataset, series):
+    return (resolve_column_name(dataset, series.x_column_id, series.x_column),
+            resolve_column_name(dataset, series.y_column_id, series.y_column))
+
+
+def test_rename_updates_dataframe_and_resolves_references(env):
     app_context, dataset, other, chart = env
     command = RenameColumnCommand(app_context, dataset.id, 0, "time")
 
     assert command.execute() is True
     assert list(dataset.data.columns) == ["time", "b"]
-    assert chart.data_series[0].x_column == "time"
-    assert chart.data_series[0].y_column == "b"
-    assert chart.fit_data[0].source_x_column == "time"
-    assert chart.fit_data[0].source_y_column == "b"
+    # The stored name is not rewritten, but the id resolves to the new name.
+    assert _resolved(dataset, chart.data_series[0]) == ("time", "b")
+    assert resolve_column_name(dataset, chart.fit_data[0].source_x_column_id,
+                               chart.fit_data[0].source_x_column) == "time"
+    assert resolve_column_name(dataset, chart.fit_data[0].source_y_column_id,
+                               chart.fit_data[0].source_y_column) == "b"
     # same column name in another dataset: untouched
-    assert chart.data_series[1].x_column == "a"
+    assert _resolved(other, chart.data_series[1]) == ("a", "a")
     assert list(other.data.columns) == ["a"]
+
+
+def test_rename_without_preexisting_ids_still_follows(env):
+    """Legacy references (name only, no id) are anchored during the rename."""
+    app_context, dataset, _, chart = env
+    # Simulate a legacy series that references columns by name only.
+    series = chart.data_series[0]
+    series.x_column_id = ""
+    series.y_column_id = ""
+
+    RenameColumnCommand(app_context, dataset.id, 0, "time").execute()
+
+    assert series.x_column_id  # backfilled
+    assert _resolved(dataset, series) == ("time", "b")
 
 
 def test_undo_and_redo_round_trip(env):
@@ -68,12 +103,13 @@ def test_undo_and_redo_round_trip(env):
 
     command.undo()
     assert list(dataset.data.columns) == ["a", "b"]
-    assert chart.data_series[0].x_column == "a"
-    assert chart.fit_data[0].source_x_column == "a"
+    assert _resolved(dataset, chart.data_series[0]) == ("a", "b")
+    assert resolve_column_name(dataset, chart.fit_data[0].source_x_column_id,
+                               chart.fit_data[0].source_x_column) == "a"
 
     command.redo()
     assert list(dataset.data.columns) == ["time", "b"]
-    assert chart.data_series[0].x_column == "time"
+    assert _resolved(dataset, chart.data_series[0]) == ("time", "b")
 
 
 def test_duplicate_name_rejected(env):
@@ -106,7 +142,7 @@ def test_undo_after_rejected_execute_is_a_noop(env):
 
     command.undo()  # CommandExecutor pushes commands even on failure; undo must not corrupt
     assert list(dataset.data.columns) == ["a", "b"]
-    assert chart.data_series[0].y_column == "b"
+    assert _resolved(dataset, chart.data_series[0]) == ("a", "b")
 
     command.redo()
     assert list(dataset.data.columns) == ["a", "b"]


### PR DESCRIPTION
resolves #79 

Dataset owns the IDs — [dataset.py]
column_ids maps current name → stable id, kept in sync with data.columns via ensure_column_ids() (called from __init__ and set_data, so every column-adding command already covered).
Helpers: get_column_id, get_column_name, rename_column (renames the DataFrame column and moves the id), and a module-level resolve_column_name(dataset, id, fallback_name).

Series/fits reference by ID — [chart.py]
DataSeries gains x_column_id/y_column_id, FitData gains source_x/y_column_id. The old name fields stay only as a fallback for references that predate IDs. Serialization and add_data_series/add_fit_data updated. Added sync_series_column_ids / sync_fit_column_ids / backfill_chart_column_ids helpers.

Rename is now event-driven — [rename_column_command.py]
No longer walks every chart rewriting names. It anchors any legacy (id-less) references once, remaps the column's name on the dataset (id preserved), and emits DATASET_COLUMN_RENAMED + CHART_UPDATED for charts that use the column. Resolution follows the id to the current name.

Resolution & consumers — [chart_editor.py], [chart_properties_panel.py], [fit_panel.py]
resolve_series_data resolves via id (lazily backfilling), fit-to-axis grouping matches by id, and the panels preselect the current column name. Creation/edit sites set the id from the picked column.

Persistence & migration — [dataset_data_manager.py]
column_ids is saved/loaded; on project load, charts are backfilled with IDs so old projects migrate automatically. Delete-columns reference detection ([delete_columns_command.py]) now matches by id with a name fallback.