### PR TITLE
Chart Properties Improvements: axis styling, log-scale base, legend placement, fonts

### DIFF
--- a/pandaplot/gui/components/common/font_family_options.py
+++ b/pandaplot/gui/components/common/font_family_options.py
@@ -1,0 +1,18 @@
+"""Font-family option list shared by every font-family picker added across
+the Chart Properties panel (chart title/subtitle, axis titles, tick
+values, legend text)."""
+
+
+def list_available_font_families() -> list[tuple[str, str]]:
+    """Sorted, deduplicated (label, value) pairs of font families installed
+    for matplotlib to use, suitable for a ValueComboBox. Always includes
+    "DejaVu Sans" (matplotlib's built-in default), which every new
+    font-family config field also uses as its fallback default -- so a
+    family chosen on one machine that's absent on another still resolves
+    to a real, always-available font rather than silently falling back to
+    something the user never selected."""
+    from matplotlib import font_manager
+
+    names = {font.name for font in font_manager.fontManager.ttflist}
+    names.add("DejaVu Sans")
+    return [(name, name) for name in sorted(names)]

--- a/pandaplot/gui/components/sidebar/chart/chart_properties_panel.py
+++ b/pandaplot/gui/components/sidebar/chart/chart_properties_panel.py
@@ -84,7 +84,7 @@ class ChartPropertiesPanel(PWidget):
         # widget after Style, below) because building the Data tab's series
         # cards calls `_rebuild_series_cards`, which calls
         # `self.axes_tab.refresh_axis_chips` to sync the Y2 chip.
-        self.axes_tab = AxesTab(self)
+        self.axes_tab = AxesTab(self.app_context, self)
         self.axes_tab.configChanged.connect(self._on_any_tab_config_changed)
 
         # Data tab: series list + per-series dataset/X/Y/label configuration

--- a/pandaplot/gui/components/sidebar/chart/chart_properties_panel.py
+++ b/pandaplot/gui/components/sidebar/chart/chart_properties_panel.py
@@ -95,7 +95,7 @@ class ChartPropertiesPanel(PWidget):
         self.data_tab.seriesListChanged.connect(
             lambda ds, fd: self.style_tab.set_series_list(ds, fd, self.data_tab.selected_index)
         )
-        self.data_tab.axesRefreshRequested.connect(lambda: self.axes_tab.refresh_axis_chips(self.current_chart))
+        self.data_tab.axesRefreshRequested.connect(self._on_axes_refresh_requested)
         self.style_tab.seriesChipSelected.connect(self.data_tab._expand_series)
         self.tab_widget.addTab(self._wrap_in_scroll_area(self.data_tab), "Data")
 
@@ -330,6 +330,13 @@ class ChartPropertiesPanel(PWidget):
         if update_type in ["fit_added", "series_added", "series_removed"]:
             self.data_tab._rebuild_series_cards()
             self.logger.debug("Chart properties panel refreshed for update: %s", update_type)
+
+    def _on_axes_refresh_requested(self):
+        """Sync both the Axes tab's chip row and the Style tab's axis-style
+        selector with whether any series currently uses the secondary Y
+        axis (see AxesTab.refresh_axis_chips / StyleTab.refresh_axis_style_selector)."""
+        self.axes_tab.refresh_axis_chips(self.current_chart)
+        self.style_tab.refresh_axis_style_selector(self.current_chart)
 
     def _on_any_tab_config_changed(self):
         if not self.current_chart:

--- a/pandaplot/gui/components/sidebar/chart/tabs/axes_tab.py
+++ b/pandaplot/gui/components/sidebar/chart/tabs/axes_tab.py
@@ -73,6 +73,7 @@ class AxesTab(QWidget):
         label_layout = QGridLayout()
         label_layout.addWidget(QLabel("Label:"), 0, 0)
         label_edit = QLineEdit()
+        label_edit.setToolTip("Supports $LaTeX$ math notation, e.g. $x^2$")
         label_layout.addWidget(label_edit, 0, 1, 1, 2)
         form_layout.addLayout(label_layout)
 

--- a/pandaplot/gui/components/sidebar/chart/tabs/axes_tab.py
+++ b/pandaplot/gui/components/sidebar/chart/tabs/axes_tab.py
@@ -41,8 +41,9 @@ class AxesTab(QWidget):
 
     configChanged = Signal()
 
-    def __init__(self, parent=None):
+    def __init__(self, app_context, parent=None):
         super().__init__(parent)
+        self.app_context = app_context
         self._chart = None
         self._updating_controls = False
 
@@ -335,10 +336,32 @@ class AxesTab(QWidget):
         self._show_axis_form(prefix)
 
     def _on_axis_auto_limits_toggled(self, prefix: str, checked: bool):
-        form = self.axes_forms[prefix]
-        form["min_spin"].setEnabled(not checked)
-        form["max_spin"].setEnabled(not checked)
+        self._refresh_range_display(prefix)
         self._on_field_changed()
+
+    def _refresh_range_display(self, prefix: str):
+        """Recompute the data-driven min/max for this axis and show it:
+        Auto shows it disabled (for reference); Manual shows it enabled
+        and freshly seeded (never restoring a previously-typed value --
+        every Auto<->Manual transition recomputes from the current data)."""
+        form = self.axes_forms[prefix]
+        auto = form["auto_toggle"].isChecked()
+        if self._chart is not None:
+            from pandaplot.gui.components.tabs.chart.chart_editor import compute_axis_data_range
+            project = self.app_context.app_state.current_project
+            computed = compute_axis_data_range(project, self._chart.data_series, prefix)
+        else:
+            computed = None
+        min_value, max_value = computed if computed is not None else (0.0, 1.0)
+        previous_guard = self._updating_controls
+        self._updating_controls = True
+        try:
+            form["min_spin"].setValue(min_value)
+            form["max_spin"].setValue(max_value)
+        finally:
+            self._updating_controls = previous_guard
+        form["min_spin"].setEnabled(not auto)
+        form["max_spin"].setEnabled(not auto)
 
     def _on_axis_tick_mode_changed(self, prefix: str):
         """Show only the field the current tick mode actually uses: Auto
@@ -608,10 +631,6 @@ class AxesTab(QWidget):
 
         auto_limits = config.get(f"{prefix}_auto_limits", True)
         form["auto_toggle"].setChecked(auto_limits)
-        form["min_spin"].setValue(config.get(f"{prefix}_min", 0.0))
-        form["max_spin"].setValue(config.get(f"{prefix}_max", 1.0))
-        form["min_spin"].setEnabled(not auto_limits)
-        form["max_spin"].setEnabled(not auto_limits)
 
         tick_mode = config.get(f"{prefix}_tick_mode", "auto")
         form["mode_control"].setCurrentValue(tick_mode)
@@ -702,6 +721,7 @@ class AxesTab(QWidget):
         try:
             for prefix in ("x", "y", "y2"):
                 self._read_axis_config(prefix, chart.config)
+                self._refresh_range_display(prefix)
             self.refresh_axis_chips(chart)
             self._show_axis_form("x")
             self.axis_chips.setCurrentValue("x")

--- a/pandaplot/gui/components/sidebar/chart/tabs/axes_tab.py
+++ b/pandaplot/gui/components/sidebar/chart/tabs/axes_tab.py
@@ -1,4 +1,6 @@
 """Axes tab: X/Y1/Y2 chip switcher over per-axis scale/limits/ticks/grid forms."""
+import math
+
 from PySide6.QtCore import Signal
 from PySide6.QtWidgets import (
     QComboBox,
@@ -95,6 +97,24 @@ class AxesTab(QWidget):
 
         scale_control = SegmentedControl([("Linear", ScaleType.LINEAR), ("Log", ScaleType.LOG)])
         form_layout.addWidget(scale_control)
+
+        log_base_row = QWidget()
+        log_base_layout = QGridLayout(log_base_row)
+        log_base_layout.setContentsMargins(0, 0, 0, 0)
+        log_base_label = QLabel("Base:")
+        log_base_layout.addWidget(log_base_label, 0, 0)
+        log_base_combo = QComboBox()
+        for text, value in [("10", 10.0), ("2", 2.0), ("e (natural log)", math.e), ("Custom...", "custom")]:
+            log_base_combo.addItem(text, value)
+        log_base_layout.addWidget(log_base_combo, 0, 1)
+        log_base_custom_spin = QDoubleSpinBox()
+        log_base_custom_spin.setRange(0.001, 1000.0)
+        log_base_custom_spin.setSingleStep(0.1)
+        log_base_custom_spin.setValue(10.0)
+        log_base_layout.addWidget(log_base_custom_spin, 1, 0, 1, 2)
+        log_base_custom_spin.setVisible(False)
+        form_layout.addWidget(log_base_row)
+        log_base_row.setVisible(False)
 
         side_control = None
         if prefix in ("y", "y2"):
@@ -242,6 +262,8 @@ class AxesTab(QWidget):
         self.axes_forms[prefix] = {
             "widget": form_widget, "label_edit": label_edit, "font_spin": font_spin,
             "scale_control": scale_control, "side_control": side_control,
+            "log_base_row": log_base_row, "log_base_combo": log_base_combo,
+            "log_base_custom_spin": log_base_custom_spin,
             "range_card": range_card, "ticks_card": ticks_card,
             "auto_toggle": auto_toggle, "min_spin": min_spin, "max_spin": max_spin,
             "mode_control": mode_control, "count_spin": count_spin, "step_spin": step_spin,
@@ -273,7 +295,9 @@ class AxesTab(QWidget):
         # attributes to hook up elsewhere), so wiring happens here.
         label_edit.textChanged.connect(self._on_field_changed)
         font_spin.valueChanged.connect(self._on_field_changed)
-        scale_control.currentValueChanged.connect(self._on_field_changed)
+        scale_control.currentValueChanged.connect(lambda _v, p=prefix: self._on_scale_changed(p))
+        log_base_combo.currentIndexChanged.connect(lambda _i, p=prefix: self._on_log_base_combo_changed(p))
+        log_base_custom_spin.valueChanged.connect(self._on_field_changed)
         if side_control is not None:
             side_control.currentValueChanged.connect(self._on_field_changed)
         auto_toggle.toggled.connect(lambda checked, p=prefix: self._on_axis_auto_limits_toggled(p, checked))
@@ -393,6 +417,29 @@ class AxesTab(QWidget):
         form["format_custom_edit"].setEnabled(form["format_combo"].currentData() == "custom")
         self._on_field_changed()
 
+    def _on_scale_changed(self, prefix: str):
+        """Show the Base row only for Log scale."""
+        form = self.axes_forms[prefix]
+        is_log = form["scale_control"].currentValue() == ScaleType.LOG
+        form["log_base_row"].setVisible(is_log)
+        self._on_field_changed()
+
+    def _on_log_base_combo_changed(self, prefix: str):
+        form = self.axes_forms[prefix]
+        form["log_base_custom_spin"].setVisible(form["log_base_combo"].currentData() == "custom")
+        self._on_field_changed()
+
+    def _resolve_log_base(self, prefix: str) -> float:
+        """Resolve the effective log base from the Base combo, reading the
+        custom spin box when "Custom..." is selected. Rejects exactly 1.0
+        (matplotlib's LogScale forbids it) by falling back to 10.0 --
+        QDoubleSpinBox can't exclude a single interior value via setRange,
+        so this is enforced here instead."""
+        form = self.axes_forms[prefix]
+        data = form["log_base_combo"].currentData()
+        base = form["log_base_custom_spin"].value() if data == "custom" else data
+        return base if base and base != 1.0 else 10.0
+
     def _on_copy_axis_settings(self, prefix: str):
         """Copy the shown Y axis's non-label settings to the other Y axis."""
         other = "y2" if prefix == "y" else "y"
@@ -401,6 +448,10 @@ class AxesTab(QWidget):
 
         target["font_spin"].setValue(source["font_spin"].value())
         target["scale_control"].setCurrentValue(source["scale_control"].currentValue())
+        target["log_base_combo"].setCurrentIndex(target["log_base_combo"].findData(source["log_base_combo"].currentData()))
+        target["log_base_custom_spin"].setValue(source["log_base_custom_spin"].value())
+        target["log_base_custom_spin"].setVisible(target["log_base_combo"].currentData() == "custom")
+        target["log_base_row"].setVisible(target["scale_control"].currentValue() == ScaleType.LOG)
         if source["side_control"] is not None and target["side_control"] is not None:
             target["side_control"].setCurrentValue(source["side_control"].currentValue())
         target["auto_toggle"].setChecked(source["auto_toggle"].isChecked())
@@ -499,6 +550,7 @@ class AxesTab(QWidget):
         config[f"{prefix}_font_size"] = form["font_spin"].value()
         if form["scale_control"].currentValue():
             config[f"{prefix}_scale"] = form["scale_control"].currentValue().value
+        config[f"{prefix}_log_base"] = self._resolve_log_base(prefix)
         if form["side_control"] is not None:
             config[f"{prefix}_side"] = form["side_control"].currentValue()
         config[f"{prefix}_auto_limits"] = form["auto_toggle"].isChecked()
@@ -537,6 +589,18 @@ class AxesTab(QWidget):
             form["scale_control"].setCurrentValue(ScaleType(scale_value))
         except ValueError:
             form["scale_control"].setCurrentValue(ScaleType.LINEAR)
+
+        log_base = config.get(f"{prefix}_log_base", 10.0)
+        preset_index = form["log_base_combo"].findData(log_base)
+        if preset_index >= 0:
+            form["log_base_combo"].setCurrentIndex(preset_index)
+            form["log_base_custom_spin"].setVisible(False)
+        else:
+            form["log_base_combo"].setCurrentIndex(form["log_base_combo"].findData("custom"))
+            form["log_base_custom_spin"].setValue(log_base)
+            form["log_base_custom_spin"].setVisible(True)
+        is_log = form["scale_control"].currentValue() == ScaleType.LOG
+        form["log_base_row"].setVisible(is_log)
 
         if form["side_control"] is not None:
             default_side = "left" if prefix == "y" else "right"

--- a/pandaplot/gui/components/sidebar/chart/tabs/axes_tab.py
+++ b/pandaplot/gui/components/sidebar/chart/tabs/axes_tab.py
@@ -111,9 +111,16 @@ class AxesTab(QWidget):
         range_layout.addWidget(auto_toggle, 0, 2)
         min_spin = QDoubleSpinBox()
         min_spin.setRange(-1e9, 1e9)
+        # Task 4 made these boxes display machine-computed data ranges (not
+        # just user-typed values); Qt's default of 2 decimal places silently
+        # rounds away small-magnitude data (e.g. 0.001-0.009 -> 0.00/0.01),
+        # which can then write degenerate limits into config on an
+        # Auto->Manual toggle.
+        min_spin.setDecimals(6)
         min_spin.setEnabled(False)
         max_spin = QDoubleSpinBox()
         max_spin.setRange(-1e9, 1e9)
+        max_spin.setDecimals(6)
         max_spin.setValue(1.0)
         max_spin.setEnabled(False)
         range_layout.addWidget(QLabel("Min:"), 1, 0)
@@ -312,10 +319,16 @@ class AxesTab(QWidget):
         self._on_field_changed()
 
     def _on_scale_changed(self, prefix: str):
-        """Show the Base row only for Log scale."""
+        """Show the Base row only for Log scale, and -- for an Auto axis --
+        refresh the displayed range so the positive-only filtering
+        `_refresh_range_display` applies for Log scale takes effect
+        immediately (matches the guard `load()` uses around the same call:
+        a Manual axis's displayed value must not be recomputed here)."""
         form = self.axes_forms[prefix]
         is_log = form["scale_control"].currentValue() == ScaleType.LOG
         form["log_base_row"].setVisible(is_log)
+        if form["auto_toggle"].isChecked():
+            self._refresh_range_display(prefix)
         self._on_field_changed()
 
     def _on_log_base_combo_changed(self, prefix: str):

--- a/pandaplot/gui/components/sidebar/chart/tabs/axes_tab.py
+++ b/pandaplot/gui/components/sidebar/chart/tabs/axes_tab.py
@@ -75,25 +75,6 @@ class AxesTab(QWidget):
         label_layout.addWidget(QLabel("Label:"), 0, 0)
         label_edit = QLineEdit()
         label_layout.addWidget(label_edit, 0, 1, 1, 2)
-
-        label_layout.addWidget(QLabel("Font size:"), 1, 0)
-        font_spin = QSpinBox()
-        font_spin.setRange(6, 32)
-        font_spin.setValue(12)
-        label_layout.addWidget(font_spin, 1, 1)
-
-        label_color_label = QLabel("Color:")
-        label_layout.addWidget(label_color_label, 2, 0)
-        label_color_row = ColorSwatchRow(AXES_SWATCH_PALETTE)
-        label_layout.addWidget(label_color_row, 2, 1)
-        match_x_label_toggle = None
-        if prefix in ("y", "y2"):
-            match_x_label_toggle = ToggleSwitch(checked=True)
-            label_layout.addWidget(QLabel("Match X:"), 2, 2)
-            label_layout.addWidget(match_x_label_toggle, 2, 3)
-            label_color_label.setVisible(False)  # hidden while matching, per default checked=True
-            label_color_row.setVisible(False)  # hidden while matching, per default checked=True
-
         form_layout.addLayout(label_layout)
 
         scale_control = SegmentedControl([("Linear", ScaleType.LINEAR), ("Log", ScaleType.LOG)])
@@ -261,7 +242,7 @@ class AxesTab(QWidget):
             form_layout.addWidget(copy_button)
 
         self.axes_forms[prefix] = {
-            "widget": form_widget, "label_edit": label_edit, "font_spin": font_spin,
+            "widget": form_widget, "label_edit": label_edit,
             "scale_control": scale_control, "side_control": side_control,
             "log_base_row": log_base_row, "log_base_combo": log_base_combo,
             "log_base_custom_spin": log_base_custom_spin,
@@ -283,9 +264,6 @@ class AxesTab(QWidget):
             "major_tick_color_label": major_tick_color_label,
             "minor_tick_color_row": minor_tick_color_row,
             "minor_tick_color_label": minor_tick_color_label,
-            "label_color_row": label_color_row,
-            "label_color_label": label_color_label,
-            "match_x_label_toggle": match_x_label_toggle,
             "match_x_colors_toggle": match_x_colors_toggle,
             "tick_label_color_row": tick_label_color_row,
             "tick_label_color_label": tick_label_color_label,
@@ -295,7 +273,6 @@ class AxesTab(QWidget):
         # are built dynamically (there are no static self.x_*/self.y_*
         # attributes to hook up elsewhere), so wiring happens here.
         label_edit.textChanged.connect(self._on_field_changed)
-        font_spin.valueChanged.connect(self._on_field_changed)
         scale_control.currentValueChanged.connect(lambda _v, p=prefix: self._on_scale_changed(p))
         log_base_combo.currentIndexChanged.connect(lambda _i, p=prefix: self._on_log_base_combo_changed(p))
         log_base_custom_spin.valueChanged.connect(self._on_field_changed)
@@ -317,10 +294,7 @@ class AxesTab(QWidget):
         spine_color_row.colorChanged.connect(self._on_field_changed)
         major_tick_color_row.colorChanged.connect(self._on_field_changed)
         minor_tick_color_row.colorChanged.connect(self._on_field_changed)
-        label_color_row.colorChanged.connect(self._on_field_changed)
         tick_label_color_row.colorChanged.connect(self._on_field_changed)
-        if match_x_label_toggle is not None:
-            match_x_label_toggle.toggled.connect(lambda checked, p=prefix: self._on_match_x_label_toggled(p, checked))
         if match_x_colors_toggle is not None:
             match_x_colors_toggle.toggled.connect(lambda checked, p=prefix: self._on_match_x_colors_toggled(p, checked))
 
@@ -395,31 +369,18 @@ class AxesTab(QWidget):
         form["minor_tick_color_row"].setVisible(checked and not matching)
         self._on_field_changed()
 
-    def _on_match_x_label_toggled(self, prefix: str, checked: bool):
-        """Hide the axis-name color swatch while it matches X's; pre-fill
-        from X's current color the first time it's revealed.
+    def _on_match_x_colors_toggled(self, prefix: str, checked: bool):
+        """Hide spine/major/minor/tick-value color swatches while this axis
+        matches X's colors for all four; pre-fill from X's current colors
+        the first time they're revealed.
 
         The pre-fill is guarded by `not self._updating_controls` so that
         `_read_axis_config`/`_on_copy_axis_settings` setting this toggle's
         checked state while loading/copying real values (which still fires
         `toggled`, since `setChecked` doesn't consult `_updating_controls`)
         can't clobber a value the caller is about to load or has already
-        loaded, by explicitly setting the swatch color themselves right
-        after this handler runs."""
-        form = self.axes_forms[prefix]
-        if not checked and not self._updating_controls:
-            form["label_color_row"].setCurrentColor(self.axes_forms["x"]["label_color_row"].currentColor())
-        form["label_color_label"].setVisible(not checked)
-        form["label_color_row"].setVisible(not checked)
-        self._on_field_changed()
-
-    def _on_match_x_colors_toggled(self, prefix: str, checked: bool):
-        """Hide spine/major/minor/tick-value color swatches while this axis
-        matches X's colors for all four; pre-fill from X's current colors
-        the first time they're revealed.
-
-        The pre-fill is guarded by `not self._updating_controls` -- see
-        `_on_match_x_label_toggled` for why."""
+        loaded, by explicitly setting the swatches themselves right after
+        this handler runs."""
         form = self.axes_forms[prefix]
         x_form = self.axes_forms["x"]
         if not checked and not self._updating_controls:
@@ -473,7 +434,6 @@ class AxesTab(QWidget):
         source = self.axes_forms[prefix]
         target = self.axes_forms[other]
 
-        target["font_spin"].setValue(source["font_spin"].value())
         target["scale_control"].setCurrentValue(source["scale_control"].currentValue())
         target["log_base_combo"].setCurrentIndex(target["log_base_combo"].findData(source["log_base_combo"].currentData()))
         target["log_base_custom_spin"].setValue(source["log_base_custom_spin"].value())
@@ -514,19 +474,17 @@ class AxesTab(QWidget):
         target["minor_grid_label"].setVisible(target_minor_enabled)
         target["minor_grid_toggle"].setVisible(target_minor_enabled)
 
-        # Match-X toggles MUST be set BEFORE the color swatches are copied
+        # Match-X toggle MUST be set BEFORE the color swatches are copied
         # from `source`: `setChecked` fires `toggled` unconditionally, and
-        # the toggled handlers pre-fill their swatches from X's *current*
+        # the toggled handler pre-fills its swatches from X's *current*
         # color whenever the new state is "not matching" (see
-        # _on_match_x_label_toggled/_on_match_x_colors_toggled). If the
-        # swatches were copied from `source` first, that pre-fill would
-        # immediately overwrite them with X's colors instead of the
-        # `source` colors we just copied. Setting the toggles first means
-        # any pre-fill the handler does gets overwritten a few lines down
-        # by the explicit `setCurrentColor(source[...])` calls below, which
-        # is what we actually want to end up in `target`.
-        if source["match_x_label_toggle"] is not None and target["match_x_label_toggle"] is not None:
-            target["match_x_label_toggle"].setChecked(source["match_x_label_toggle"].isChecked())
+        # _on_match_x_colors_toggled). If the swatches were copied from
+        # `source` first, that pre-fill would immediately overwrite them
+        # with X's colors instead of the `source` colors we just copied.
+        # Setting the toggle first means any pre-fill the handler does gets
+        # overwritten a few lines down by the explicit
+        # `setCurrentColor(source[...])` calls below, which is what we
+        # actually want to end up in `target`.
         if source["match_x_colors_toggle"] is not None and target["match_x_colors_toggle"] is not None:
             target["match_x_colors_toggle"].setChecked(source["match_x_colors_toggle"].isChecked())
 
@@ -534,11 +492,8 @@ class AxesTab(QWidget):
         target["major_tick_color_row"].setCurrentColor(source["major_tick_color_row"].currentColor())
         target["minor_tick_color_row"].setCurrentColor(source["minor_tick_color_row"].currentColor())
 
-        target["label_color_row"].setCurrentColor(source["label_color_row"].currentColor())
         target["tick_label_color_row"].setCurrentColor(source["tick_label_color_row"].currentColor())
 
-        target["label_color_label"].setVisible(not target["match_x_label_toggle"].isChecked())
-        target["label_color_row"].setVisible(not target["match_x_label_toggle"].isChecked())
         target_matching_colors = target["match_x_colors_toggle"].isChecked()
         target["spine_color_label"].setVisible(not target_matching_colors)
         target["spine_color_row"].setVisible(not target_matching_colors)
@@ -574,7 +529,6 @@ class AxesTab(QWidget):
         """Write one axis form's widget values into `config` (the mutable chart.config dict)."""
         form = self.axes_forms[prefix]
         config[f"{prefix}_label"] = form["label_edit"].text()
-        config[f"{prefix}_font_size"] = form["font_spin"].value()
         if form["scale_control"].currentValue():
             config[f"{prefix}_scale"] = form["scale_control"].currentValue().value
         config[f"{prefix}_log_base"] = self._resolve_log_base(prefix)
@@ -596,10 +550,7 @@ class AxesTab(QWidget):
         config[f"{prefix}_spine_color"] = form["spine_color_row"].currentColor()
         config[f"{prefix}_major_tick_color"] = form["major_tick_color_row"].currentColor()
         config[f"{prefix}_minor_tick_color"] = form["minor_tick_color_row"].currentColor()
-        config[f"{prefix}_label_color"] = form["label_color_row"].currentColor()
         config[f"{prefix}_tick_label_color"] = form["tick_label_color_row"].currentColor()
-        if form["match_x_label_toggle"] is not None:
-            config[f"{prefix}_match_x_label_color"] = form["match_x_label_toggle"].isChecked()
         if form["match_x_colors_toggle"] is not None:
             config[f"{prefix}_match_x_colors"] = form["match_x_colors_toggle"].isChecked()
 
@@ -609,7 +560,6 @@ class AxesTab(QWidget):
         write half-loaded values back out."""
         form = self.axes_forms[prefix]
         form["label_edit"].setText(config.get(f"{prefix}_label", ""))
-        form["font_spin"].setValue(config.get(f"{prefix}_font_size", 12))
 
         scale_value = config.get(f"{prefix}_scale", "linear")
         try:
@@ -675,24 +625,19 @@ class AxesTab(QWidget):
         form["minor_grid_label"].setVisible(minor_ticks_enabled)
         form["minor_grid_toggle"].setVisible(minor_ticks_enabled)
 
-        # Match-X toggles MUST be set BEFORE the color swatches they gate.
+        # Match-X toggle MUST be set BEFORE the color swatches it gates.
         # `ToggleSwitch.setChecked` emits `toggled` unconditionally -- even
         # while `self._updating_controls` is True -- and the toggled
-        # handlers (`_on_match_x_label_toggled`/`_on_match_x_colors_toggled`)
-        # pre-fill their swatches from X's *current* color whenever the new
-        # state is "not matching". If the swatches were populated from
-        # `config` first, that pre-fill would silently overwrite a saved
-        # custom color with X's color. Setting the toggles first means any
-        # pre-fill the handler does gets overwritten a few lines down by the
-        # explicit `setCurrentColor(config.get(...))` calls below, which are
-        # the actual saved values we want. (Mirrors style_tab.py's
+        # handler (`_on_match_x_colors_toggled`) pre-fills its swatches from
+        # X's *current* color whenever the new state is "not matching". If
+        # the swatches were populated from `config` first, that pre-fill
+        # would silently overwrite a saved custom color with X's color.
+        # Setting the toggle first means any pre-fill the handler does gets
+        # overwritten a few lines down by the explicit
+        # `setCurrentColor(config.get(...))` calls below, which are the
+        # actual saved values we want. (Mirrors style_tab.py's
         # load_chart_style, which sets subtitle_match_title_toggle before
         # subtitle_color_row for the same reason.)
-        match_label = True
-        if form["match_x_label_toggle"] is not None:
-            match_label = config.get(f"{prefix}_match_x_label_color", True)
-            form["match_x_label_toggle"].setChecked(match_label)
-
         match_colors = True
         if form["match_x_colors_toggle"] is not None:
             match_colors = config.get(f"{prefix}_match_x_colors", True)
@@ -704,12 +649,8 @@ class AxesTab(QWidget):
         form["minor_tick_color_label"].setVisible(minor_ticks_enabled)
         form["minor_tick_color_row"].setVisible(minor_ticks_enabled)
 
-        form["label_color_row"].setCurrentColor(config.get(f"{prefix}_label_color", "#000000"))
         form["tick_label_color_row"].setCurrentColor(config.get(f"{prefix}_tick_label_color", "#000000"))
 
-        if form["match_x_label_toggle"] is not None:
-            form["label_color_label"].setVisible(not match_label)
-            form["label_color_row"].setVisible(not match_label)
         if form["match_x_colors_toggle"] is not None:
             form["spine_color_label"].setVisible(not match_colors)
             form["spine_color_row"].setVisible(not match_colors)
@@ -783,9 +724,6 @@ class AxesTab(QWidget):
             form["spine_color_row"].set_tokens(tokens)
             form["major_tick_color_row"].set_tokens(tokens)
             form["minor_tick_color_row"].set_tokens(tokens)
-            form["label_color_row"].set_tokens(tokens)
             form["tick_label_color_row"].set_tokens(tokens)
-            if form["match_x_label_toggle"] is not None:
-                form["match_x_label_toggle"].set_tokens(tokens)
             if form["match_x_colors_toggle"] is not None:
                 form["match_x_colors_toggle"].set_tokens(tokens)

--- a/pandaplot/gui/components/sidebar/chart/tabs/axes_tab.py
+++ b/pandaplot/gui/components/sidebar/chart/tabs/axes_tab.py
@@ -631,6 +631,16 @@ class AxesTab(QWidget):
 
         auto_limits = config.get(f"{prefix}_auto_limits", True)
         form["auto_toggle"].setChecked(auto_limits)
+        # Auto mode's displayed min/max is owned by `_refresh_range_display`
+        # (recomputed from live data whenever it's called). Manual mode has
+        # no such recompute on load -- per spec, a Manual axis's value only
+        # ever changes via an explicit Auto->Manual toggle or the user
+        # typing, never merely by loading/reopening a chart -- so it must be
+        # restored here from the actual saved config.
+        form["min_spin"].setValue(config.get(f"{prefix}_min", 0.0))
+        form["max_spin"].setValue(config.get(f"{prefix}_max", 1.0))
+        form["min_spin"].setEnabled(not auto_limits)
+        form["max_spin"].setEnabled(not auto_limits)
 
         tick_mode = config.get(f"{prefix}_tick_mode", "auto")
         form["mode_control"].setCurrentValue(tick_mode)
@@ -721,7 +731,14 @@ class AxesTab(QWidget):
         try:
             for prefix in ("x", "y", "y2"):
                 self._read_axis_config(prefix, chart.config)
-                self._refresh_range_display(prefix)
+                # Only Auto axes get their range recomputed from live data on
+                # load -- `_read_axis_config` just restored a Manual axis's
+                # actually-saved min/max above, and merely loading/reopening
+                # a chart must not overwrite it (only an explicit
+                # Auto->Manual toggle should recompute; see
+                # _on_axis_auto_limits_toggled).
+                if self.axes_forms[prefix]["auto_toggle"].isChecked():
+                    self._refresh_range_display(prefix)
             self.refresh_axis_chips(chart)
             self._show_axis_form("x")
             self.axis_chips.setCurrentValue("x")

--- a/pandaplot/gui/components/sidebar/chart/tabs/axes_tab.py
+++ b/pandaplot/gui/components/sidebar/chart/tabs/axes_tab.py
@@ -349,7 +349,11 @@ class AxesTab(QWidget):
         if self._chart is not None:
             from pandaplot.gui.components.tabs.chart.chart_editor import compute_axis_data_range
             project = self.app_context.app_state.current_project
-            computed = compute_axis_data_range(project, self._chart.data_series, prefix)
+            # A Log-scaled axis must ignore non-positive data points, same as
+            # matplotlib's own autoscale would -- otherwise a computed min <= 0
+            # gets shown here and later rejected/ignored by set_xlim/set_ylim.
+            is_log = form["scale_control"].currentValue() == ScaleType.LOG
+            computed = compute_axis_data_range(project, self._chart.data_series, prefix, positive_only=is_log)
         else:
             computed = None
         min_value, max_value = computed if computed is not None else (0.0, 1.0)

--- a/pandaplot/gui/components/sidebar/chart/tabs/axes_tab.py
+++ b/pandaplot/gui/components/sidebar/chart/tabs/axes_tab.py
@@ -16,7 +16,6 @@ from PySide6.QtWidgets import (
 
 from pandaplot.gui.components.common.card import Card
 from pandaplot.gui.components.common.chip_row import ChipRow
-from pandaplot.gui.components.common.color_swatch_row import ColorSwatchRow
 from pandaplot.gui.components.common.section_header import SectionHeader
 from pandaplot.gui.components.common.segmented_control import SegmentedControl
 from pandaplot.gui.components.common.toggle_switch import ToggleSwitch
@@ -191,49 +190,6 @@ class AxesTab(QWidget):
 
         form_layout.addWidget(ticks_card)
 
-        colors_card = Card()
-        colors_layout = QGridLayout(colors_card)
-        colors_layout.addWidget(SectionHeader("Colors"), 0, 0, 1, 2)
-
-        spine_color_label = QLabel("Spine:")
-        colors_layout.addWidget(spine_color_label, 1, 0)
-        spine_color_row = ColorSwatchRow(AXES_SWATCH_PALETTE)
-        colors_layout.addWidget(spine_color_row, 1, 1)
-
-        major_tick_color_label = QLabel("Major ticks:")
-        colors_layout.addWidget(major_tick_color_label, 2, 0)
-        major_tick_color_row = ColorSwatchRow(AXES_SWATCH_PALETTE)
-        colors_layout.addWidget(major_tick_color_row, 2, 1)
-
-        minor_tick_color_label = QLabel("Minor ticks:")
-        colors_layout.addWidget(minor_tick_color_label, 3, 0)
-        minor_tick_color_row = ColorSwatchRow(AXES_SWATCH_PALETTE)
-        colors_layout.addWidget(minor_tick_color_row, 3, 1)
-        minor_tick_color_label.setVisible(False)
-        minor_tick_color_row.setVisible(False)
-
-        match_x_colors_toggle = None
-        if prefix in ("y", "y2"):
-            match_x_colors_toggle = ToggleSwitch(checked=True)
-            colors_layout.addWidget(QLabel("Match X:"), 4, 0)
-            colors_layout.addWidget(match_x_colors_toggle, 4, 1)
-
-        tick_label_color_label = QLabel("Tick values:")
-        colors_layout.addWidget(tick_label_color_label, 5, 0)
-        tick_label_color_row = ColorSwatchRow(AXES_SWATCH_PALETTE)
-        colors_layout.addWidget(tick_label_color_row, 5, 1)
-
-        if match_x_colors_toggle is not None:
-            # Hidden while matching X, per default checked=True.
-            spine_color_label.setVisible(False)
-            spine_color_row.setVisible(False)
-            major_tick_color_label.setVisible(False)
-            major_tick_color_row.setVisible(False)
-            tick_label_color_label.setVisible(False)
-            tick_label_color_row.setVisible(False)
-
-        form_layout.addWidget(colors_card)
-
         copy_button = None
         if prefix in ("y", "y2"):
             copy_button = QPushButton("Copy settings to Y axis")
@@ -257,16 +213,6 @@ class AxesTab(QWidget):
             "minor_tick_direction_control": minor_tick_direction_control,
             "minor_grid_label": minor_grid_label,
             "minor_grid_toggle": minor_grid_toggle,
-            "colors_card": colors_card,
-            "spine_color_row": spine_color_row,
-            "spine_color_label": spine_color_label,
-            "major_tick_color_row": major_tick_color_row,
-            "major_tick_color_label": major_tick_color_label,
-            "minor_tick_color_row": minor_tick_color_row,
-            "minor_tick_color_label": minor_tick_color_label,
-            "match_x_colors_toggle": match_x_colors_toggle,
-            "tick_label_color_row": tick_label_color_row,
-            "tick_label_color_label": tick_label_color_label,
         }
 
         # Wire this form's widgets directly to shared handlers - the forms
@@ -291,12 +237,6 @@ class AxesTab(QWidget):
         minor_ticks_toggle.toggled.connect(lambda checked, p=prefix: self._on_minor_ticks_toggled(p, checked))
         minor_tick_direction_control.currentValueChanged.connect(self._on_field_changed)
         minor_grid_toggle.toggled.connect(self._on_field_changed)
-        spine_color_row.colorChanged.connect(self._on_field_changed)
-        major_tick_color_row.colorChanged.connect(self._on_field_changed)
-        minor_tick_color_row.colorChanged.connect(self._on_field_changed)
-        tick_label_color_row.colorChanged.connect(self._on_field_changed)
-        if match_x_colors_toggle is not None:
-            match_x_colors_toggle.toggled.connect(lambda checked, p=prefix: self._on_match_x_colors_toggled(p, checked))
 
         form_widget.setVisible(False)
         self._axis_form_container_layout.addWidget(form_widget)
@@ -354,50 +294,15 @@ class AxesTab(QWidget):
         self._on_field_changed()
 
     def _on_minor_ticks_toggled(self, prefix: str, checked: bool):
-        """Show the minor-tick direction control only once minor ticks are
-        actually enabled -- it has nothing to apply to otherwise. The minor
-        tick color swatch is additionally gated by the Colors card's
-        "Match X" toggle (when present): it should only show once minor
-        ticks are on AND this axis isn't matching X's colors."""
+        """Show the minor-tick direction control and minor grid toggle only
+        once minor ticks are actually enabled -- they have nothing to apply
+        to otherwise. (Minor-tick *color* visibility is now owned by
+        StyleTab's Colors card, not this tab.)"""
         form = self.axes_forms[prefix]
         form["minor_tick_direction_label"].setVisible(checked)
         form["minor_tick_direction_control"].setVisible(checked)
         form["minor_grid_label"].setVisible(checked)
         form["minor_grid_toggle"].setVisible(checked)
-        matching = form["match_x_colors_toggle"] is not None and form["match_x_colors_toggle"].isChecked()
-        form["minor_tick_color_label"].setVisible(checked and not matching)
-        form["minor_tick_color_row"].setVisible(checked and not matching)
-        self._on_field_changed()
-
-    def _on_match_x_colors_toggled(self, prefix: str, checked: bool):
-        """Hide spine/major/minor/tick-value color swatches while this axis
-        matches X's colors for all four; pre-fill from X's current colors
-        the first time they're revealed.
-
-        The pre-fill is guarded by `not self._updating_controls` so that
-        `_read_axis_config`/`_on_copy_axis_settings` setting this toggle's
-        checked state while loading/copying real values (which still fires
-        `toggled`, since `setChecked` doesn't consult `_updating_controls`)
-        can't clobber a value the caller is about to load or has already
-        loaded, by explicitly setting the swatches themselves right after
-        this handler runs."""
-        form = self.axes_forms[prefix]
-        x_form = self.axes_forms["x"]
-        if not checked and not self._updating_controls:
-            form["spine_color_row"].setCurrentColor(x_form["spine_color_row"].currentColor())
-            form["major_tick_color_row"].setCurrentColor(x_form["major_tick_color_row"].currentColor())
-            form["minor_tick_color_row"].setCurrentColor(x_form["minor_tick_color_row"].currentColor())
-            form["tick_label_color_row"].setCurrentColor(x_form["tick_label_color_row"].currentColor())
-        form["spine_color_label"].setVisible(not checked)
-        form["spine_color_row"].setVisible(not checked)
-        form["major_tick_color_label"].setVisible(not checked)
-        form["major_tick_color_row"].setVisible(not checked)
-        # minor_tick_color_row's visibility is also gated by minor_ticks_toggle
-        # (see _on_minor_ticks_toggled) -- both conditions must hold.
-        form["minor_tick_color_row"].setVisible(not checked and form["minor_ticks_toggle"].isChecked())
-        form["minor_tick_color_label"].setVisible(not checked and form["minor_ticks_toggle"].isChecked())
-        form["tick_label_color_label"].setVisible(not checked)
-        form["tick_label_color_row"].setVisible(not checked)
         self._on_field_changed()
 
     def _on_axis_tick_format_changed(self, prefix: str):
@@ -469,40 +374,8 @@ class AxesTab(QWidget):
         target_minor_enabled = target["minor_ticks_toggle"].isChecked()
         target["minor_tick_direction_label"].setVisible(target_minor_enabled)
         target["minor_tick_direction_control"].setVisible(target_minor_enabled)
-        target["minor_tick_color_label"].setVisible(target_minor_enabled)
-        target["minor_tick_color_row"].setVisible(target_minor_enabled)
         target["minor_grid_label"].setVisible(target_minor_enabled)
         target["minor_grid_toggle"].setVisible(target_minor_enabled)
-
-        # Match-X toggle MUST be set BEFORE the color swatches are copied
-        # from `source`: `setChecked` fires `toggled` unconditionally, and
-        # the toggled handler pre-fills its swatches from X's *current*
-        # color whenever the new state is "not matching" (see
-        # _on_match_x_colors_toggled). If the swatches were copied from
-        # `source` first, that pre-fill would immediately overwrite them
-        # with X's colors instead of the `source` colors we just copied.
-        # Setting the toggle first means any pre-fill the handler does gets
-        # overwritten a few lines down by the explicit
-        # `setCurrentColor(source[...])` calls below, which is what we
-        # actually want to end up in `target`.
-        if source["match_x_colors_toggle"] is not None and target["match_x_colors_toggle"] is not None:
-            target["match_x_colors_toggle"].setChecked(source["match_x_colors_toggle"].isChecked())
-
-        target["spine_color_row"].setCurrentColor(source["spine_color_row"].currentColor())
-        target["major_tick_color_row"].setCurrentColor(source["major_tick_color_row"].currentColor())
-        target["minor_tick_color_row"].setCurrentColor(source["minor_tick_color_row"].currentColor())
-
-        target["tick_label_color_row"].setCurrentColor(source["tick_label_color_row"].currentColor())
-
-        target_matching_colors = target["match_x_colors_toggle"].isChecked()
-        target["spine_color_label"].setVisible(not target_matching_colors)
-        target["spine_color_row"].setVisible(not target_matching_colors)
-        target["major_tick_color_label"].setVisible(not target_matching_colors)
-        target["major_tick_color_row"].setVisible(not target_matching_colors)
-        target["tick_label_color_label"].setVisible(not target_matching_colors)
-        target["tick_label_color_row"].setVisible(not target_matching_colors)
-        target["minor_tick_color_row"].setVisible(not target_matching_colors and target["minor_ticks_toggle"].isChecked())
-        target["minor_tick_color_label"].setVisible(not target_matching_colors and target["minor_ticks_toggle"].isChecked())
 
         self._on_field_changed()
 
@@ -547,12 +420,6 @@ class AxesTab(QWidget):
         config[f"{prefix}_minor_ticks"] = form["minor_ticks_toggle"].isChecked()
         config[f"{prefix}_minor_tick_direction"] = form["minor_tick_direction_control"].currentValue()
         config[f"{prefix}_show_minor_grid"] = form["minor_grid_toggle"].isChecked()
-        config[f"{prefix}_spine_color"] = form["spine_color_row"].currentColor()
-        config[f"{prefix}_major_tick_color"] = form["major_tick_color_row"].currentColor()
-        config[f"{prefix}_minor_tick_color"] = form["minor_tick_color_row"].currentColor()
-        config[f"{prefix}_tick_label_color"] = form["tick_label_color_row"].currentColor()
-        if form["match_x_colors_toggle"] is not None:
-            config[f"{prefix}_match_x_colors"] = form["match_x_colors_toggle"].isChecked()
 
     def _read_axis_config(self, prefix: str, config: dict):
         """Populate one axis form's widgets from `config`. Assumes the caller
@@ -625,42 +492,6 @@ class AxesTab(QWidget):
         form["minor_grid_label"].setVisible(minor_ticks_enabled)
         form["minor_grid_toggle"].setVisible(minor_ticks_enabled)
 
-        # Match-X toggle MUST be set BEFORE the color swatches it gates.
-        # `ToggleSwitch.setChecked` emits `toggled` unconditionally -- even
-        # while `self._updating_controls` is True -- and the toggled
-        # handler (`_on_match_x_colors_toggled`) pre-fills its swatches from
-        # X's *current* color whenever the new state is "not matching". If
-        # the swatches were populated from `config` first, that pre-fill
-        # would silently overwrite a saved custom color with X's color.
-        # Setting the toggle first means any pre-fill the handler does gets
-        # overwritten a few lines down by the explicit
-        # `setCurrentColor(config.get(...))` calls below, which are the
-        # actual saved values we want. (Mirrors style_tab.py's
-        # load_chart_style, which sets subtitle_match_title_toggle before
-        # subtitle_color_row for the same reason.)
-        match_colors = True
-        if form["match_x_colors_toggle"] is not None:
-            match_colors = config.get(f"{prefix}_match_x_colors", True)
-            form["match_x_colors_toggle"].setChecked(match_colors)
-
-        form["spine_color_row"].setCurrentColor(config.get(f"{prefix}_spine_color", "#000000"))
-        form["major_tick_color_row"].setCurrentColor(config.get(f"{prefix}_major_tick_color", "#000000"))
-        form["minor_tick_color_row"].setCurrentColor(config.get(f"{prefix}_minor_tick_color", "#000000"))
-        form["minor_tick_color_label"].setVisible(minor_ticks_enabled)
-        form["minor_tick_color_row"].setVisible(minor_ticks_enabled)
-
-        form["tick_label_color_row"].setCurrentColor(config.get(f"{prefix}_tick_label_color", "#000000"))
-
-        if form["match_x_colors_toggle"] is not None:
-            form["spine_color_label"].setVisible(not match_colors)
-            form["spine_color_row"].setVisible(not match_colors)
-            form["major_tick_color_label"].setVisible(not match_colors)
-            form["major_tick_color_row"].setVisible(not match_colors)
-            form["tick_label_color_label"].setVisible(not match_colors)
-            form["tick_label_color_row"].setVisible(not match_colors)
-            form["minor_tick_color_row"].setVisible(not match_colors and minor_ticks_enabled)
-            form["minor_tick_color_label"].setVisible(not match_colors and minor_ticks_enabled)
-
     def _on_field_changed(self):
         if self._chart is None or self._updating_controls:
             return
@@ -720,10 +551,3 @@ class AxesTab(QWidget):
             form["minor_ticks_toggle"].set_tokens(tokens)
             form["minor_tick_direction_control"].set_tokens(tokens)
             form["minor_grid_toggle"].set_tokens(tokens)
-            form["colors_card"].set_tokens(tokens)
-            form["spine_color_row"].set_tokens(tokens)
-            form["major_tick_color_row"].set_tokens(tokens)
-            form["minor_tick_color_row"].set_tokens(tokens)
-            form["tick_label_color_row"].set_tokens(tokens)
-            if form["match_x_colors_toggle"] is not None:
-                form["match_x_colors_toggle"].set_tokens(tokens)

--- a/pandaplot/gui/components/sidebar/chart/tabs/chart_tab.py
+++ b/pandaplot/gui/components/sidebar/chart/tabs/chart_tab.py
@@ -50,11 +50,12 @@ class ChartTab(QWidget):
 
         info_layout.addWidget(QLabel("Title:"), 0, 0)
         self.title_edit = QLineEdit()
+        self.title_edit.setPlaceholderText("Chart title (supports $LaTeX$ math)")
         info_layout.addWidget(self.title_edit, 0, 1, 1, 2)
 
         info_layout.addWidget(QLabel("Subtitle:"), 1, 0)
         self.subtitle_edit = QLineEdit()
-        self.subtitle_edit.setPlaceholderText("Optional")
+        self.subtitle_edit.setPlaceholderText("Optional (supports $LaTeX$ math)")
         info_layout.addWidget(self.subtitle_edit, 1, 1, 1, 2)
 
         info_layout.addWidget(QLabel("Type:"), 2, 0)

--- a/pandaplot/gui/components/sidebar/chart/tabs/legend_tab.py
+++ b/pandaplot/gui/components/sidebar/chart/tabs/legend_tab.py
@@ -2,6 +2,7 @@
 from PySide6.QtCore import Signal
 from PySide6.QtWidgets import (
     QComboBox,
+    QDoubleSpinBox,
     QGridLayout,
     QGroupBox,
     QHBoxLayout,
@@ -45,18 +46,49 @@ class LegendTab(QWidget):
         legend_layout.addWidget(QLabel("Position:"), 0, 0)
         self.legend_position_combo = QComboBox()
         for position in LegendPosition:
-            self.legend_position_combo.addItem(position.value.title(), position)
+            self.legend_position_combo.addItem(position.value.title(), position.value)
+        for label, value in [
+            ("Outside Right", "outside_right"),
+            ("Outside Top", "outside_top"),
+            ("Outside Bottom", "outside_bottom"),
+            ("Custom...", "custom"),
+        ]:
+            self.legend_position_combo.addItem(label, value)
         legend_layout.addWidget(self.legend_position_combo, 0, 1)
 
-        legend_layout.addWidget(QLabel("Font Size:"), 1, 0)
+        self.legend_custom_row = QWidget()
+        custom_layout = QGridLayout(self.legend_custom_row)
+        custom_layout.setContentsMargins(0, 0, 0, 0)
+        custom_layout.addWidget(QLabel("X:"), 0, 0)
+        self.legend_custom_x_spin = QDoubleSpinBox()
+        self.legend_custom_x_spin.setRange(0.0, 1.0)
+        self.legend_custom_x_spin.setSingleStep(0.05)
+        self.legend_custom_x_spin.setValue(1.02)
+        custom_layout.addWidget(self.legend_custom_x_spin, 0, 1)
+        custom_layout.addWidget(QLabel("Y:"), 1, 0)
+        self.legend_custom_y_spin = QDoubleSpinBox()
+        self.legend_custom_y_spin.setRange(0.0, 1.0)
+        self.legend_custom_y_spin.setSingleStep(0.05)
+        self.legend_custom_y_spin.setValue(0.5)
+        custom_layout.addWidget(self.legend_custom_y_spin, 1, 1)
+        custom_layout.addWidget(QLabel("Anchor:"), 2, 0)
+        self.legend_custom_anchor_combo = QComboBox()
+        for anchor in ("upper left", "upper right", "lower left", "lower right", "center",
+                       "center left", "center right", "upper center", "lower center"):
+            self.legend_custom_anchor_combo.addItem(anchor.title(), anchor)
+        custom_layout.addWidget(self.legend_custom_anchor_combo, 2, 1)
+        legend_layout.addWidget(self.legend_custom_row, 1, 0, 1, 2)
+        self.legend_custom_row.setVisible(False)
+
+        legend_layout.addWidget(QLabel("Font Size:"), 2, 0)
         self.legend_font_size_spin = QSpinBox()
         self.legend_font_size_spin.setRange(6, 18)
         self.legend_font_size_spin.setValue(10)
-        legend_layout.addWidget(self.legend_font_size_spin, 1, 1)
+        legend_layout.addWidget(self.legend_font_size_spin, 2, 1)
 
-        legend_layout.addWidget(QLabel("Columns:"), 2, 0)
+        legend_layout.addWidget(QLabel("Columns:"), 3, 0)
         self.legend_columns_control = SegmentedControl([("1", 1), ("2", 2), ("3", 3)])
-        legend_layout.addWidget(self.legend_columns_control, 2, 1)
+        legend_layout.addWidget(self.legend_columns_control, 3, 1)
 
         layout.addWidget(legend_group)
 
@@ -76,12 +108,19 @@ class LegendTab(QWidget):
         layout.addStretch()
 
         self.show_legend_toggle.toggled.connect(self._on_show_legend_toggled)
-        self.legend_position_combo.currentIndexChanged.connect(self._on_field_changed)
+        self.legend_position_combo.currentIndexChanged.connect(self._on_position_changed)
+        self.legend_custom_x_spin.valueChanged.connect(self._on_field_changed)
+        self.legend_custom_y_spin.valueChanged.connect(self._on_field_changed)
+        self.legend_custom_anchor_combo.currentIndexChanged.connect(self._on_field_changed)
         self.legend_font_size_spin.valueChanged.connect(self._on_field_changed)
         self.legend_columns_control.currentValueChanged.connect(self._on_field_changed)
         self.legend_show_frame_toggle.toggled.connect(self._on_field_changed)
         self.legend_bg_color_row.colorChanged.connect(self._on_field_changed)
         self.legend_bg_opacity_slider.valueChanged.connect(self._on_field_changed)
+
+    def _on_position_changed(self):
+        self.legend_custom_row.setVisible(self.legend_position_combo.currentData() == "custom")
+        self._on_field_changed()
 
     def _on_show_legend_toggled(self, _checked: bool):
         self._update_legend_controls_enabled()
@@ -92,6 +131,9 @@ class LegendTab(QWidget):
         show_legend = self.show_legend_toggle.isChecked()
         for control in (
             self.legend_position_combo,
+            self.legend_custom_x_spin,
+            self.legend_custom_y_spin,
+            self.legend_custom_anchor_combo,
             self.legend_font_size_spin,
             self.legend_columns_control,
             self.legend_show_frame_toggle,
@@ -106,12 +148,15 @@ class LegendTab(QWidget):
         config = self._chart.config
         config["show_legend"] = self.show_legend_toggle.isChecked()
         if self.legend_position_combo.currentData():
-            config["legend_position"] = self.legend_position_combo.currentData().value
+            config["legend_position"] = self.legend_position_combo.currentData()
         config["legend_font_size"] = self.legend_font_size_spin.value()
         config["legend_columns"] = self.legend_columns_control.currentValue()
         config["legend_show_frame"] = self.legend_show_frame_toggle.isChecked()
         config["legend_bg_color"] = self.legend_bg_color_row.currentColor()
         config["legend_bg_alpha"] = self.legend_bg_opacity_slider.value()
+        config["legend_custom_x"] = self.legend_custom_x_spin.value()
+        config["legend_custom_y"] = self.legend_custom_y_spin.value()
+        config["legend_custom_anchor"] = self.legend_custom_anchor_combo.currentData()
         self.configChanged.emit()
 
     def load(self, chart):
@@ -122,11 +167,13 @@ class LegendTab(QWidget):
             config = chart.config
             self.show_legend_toggle.setChecked(config.get("show_legend", True))
             legend_position_value = config.get("legend_position", "upper right")
-            for i in range(self.legend_position_combo.count()):
-                if (self.legend_position_combo.itemData(i)
-                        and self.legend_position_combo.itemData(i).value == legend_position_value):
-                    self.legend_position_combo.setCurrentIndex(i)
-                    break
+            position_index = self.legend_position_combo.findData(legend_position_value)
+            self.legend_position_combo.setCurrentIndex(position_index if position_index >= 0 else 0)
+            self.legend_custom_x_spin.setValue(config.get("legend_custom_x", 1.02))
+            self.legend_custom_y_spin.setValue(config.get("legend_custom_y", 0.5))
+            anchor_index = self.legend_custom_anchor_combo.findData(config.get("legend_custom_anchor", "center left"))
+            self.legend_custom_anchor_combo.setCurrentIndex(anchor_index if anchor_index >= 0 else 0)
+            self.legend_custom_row.setVisible(legend_position_value == "custom")
             self.legend_font_size_spin.setValue(config.get("legend_font_size", 10))
             self.legend_columns_control.setCurrentValue(config.get("legend_columns", 1))
             self.legend_show_frame_toggle.setChecked(config.get("legend_show_frame", True))
@@ -139,12 +186,15 @@ class LegendTab(QWidget):
     def apply_to(self, chart):
         chart.config["show_legend"] = self.show_legend_toggle.isChecked()
         if self.legend_position_combo.currentData():
-            chart.config["legend_position"] = self.legend_position_combo.currentData().value
+            chart.config["legend_position"] = self.legend_position_combo.currentData()
         chart.config["legend_font_size"] = self.legend_font_size_spin.value()
         chart.config["legend_columns"] = self.legend_columns_control.currentValue()
         chart.config["legend_show_frame"] = self.legend_show_frame_toggle.isChecked()
         chart.config["legend_bg_color"] = self.legend_bg_color_row.currentColor()
         chart.config["legend_bg_alpha"] = self.legend_bg_opacity_slider.value()
+        chart.config["legend_custom_x"] = self.legend_custom_x_spin.value()
+        chart.config["legend_custom_y"] = self.legend_custom_y_spin.value()
+        chart.config["legend_custom_anchor"] = self.legend_custom_anchor_combo.currentData()
 
     def clear(self):
         self._chart = None

--- a/pandaplot/gui/components/sidebar/chart/tabs/legend_tab.py
+++ b/pandaplot/gui/components/sidebar/chart/tabs/legend_tab.py
@@ -14,10 +14,12 @@ from PySide6.QtWidgets import (
 
 from pandaplot.gui.components.common.card import Card
 from pandaplot.gui.components.common.color_swatch_row import ColorSwatchRow
+from pandaplot.gui.components.common.font_family_options import list_available_font_families
 from pandaplot.gui.components.common.section_header import SectionHeader
 from pandaplot.gui.components.common.segmented_control import SegmentedControl
 from pandaplot.gui.components.common.slider_with_spinbox import SliderWithSpinbox
 from pandaplot.gui.components.common.toggle_switch import ToggleSwitch
+from pandaplot.gui.components.common.value_combo_box import ValueComboBox
 from pandaplot.models.chart.chart_configuration import LegendPosition
 
 
@@ -90,6 +92,10 @@ class LegendTab(QWidget):
         self.legend_columns_control = SegmentedControl([("1", 1), ("2", 2), ("3", 3)])
         legend_layout.addWidget(self.legend_columns_control, 3, 1)
 
+        legend_layout.addWidget(QLabel("Font family:"), 4, 0)
+        self.legend_font_family_combo = ValueComboBox(list_available_font_families())
+        legend_layout.addWidget(self.legend_font_family_combo, 4, 1)
+
         layout.addWidget(legend_group)
 
         frame_card = Card()
@@ -114,6 +120,7 @@ class LegendTab(QWidget):
         self.legend_custom_anchor_combo.currentIndexChanged.connect(self._on_field_changed)
         self.legend_font_size_spin.valueChanged.connect(self._on_field_changed)
         self.legend_columns_control.currentValueChanged.connect(self._on_field_changed)
+        self.legend_font_family_combo.currentValueChanged.connect(self._on_field_changed)
         self.legend_show_frame_toggle.toggled.connect(self._on_field_changed)
         self.legend_bg_color_row.colorChanged.connect(self._on_field_changed)
         self.legend_bg_opacity_slider.valueChanged.connect(self._on_field_changed)
@@ -136,6 +143,7 @@ class LegendTab(QWidget):
             self.legend_custom_anchor_combo,
             self.legend_font_size_spin,
             self.legend_columns_control,
+            self.legend_font_family_combo,
             self.legend_show_frame_toggle,
             self.legend_bg_color_row,
             self.legend_bg_opacity_slider,
@@ -151,6 +159,7 @@ class LegendTab(QWidget):
             config["legend_position"] = self.legend_position_combo.currentData()
         config["legend_font_size"] = self.legend_font_size_spin.value()
         config["legend_columns"] = self.legend_columns_control.currentValue()
+        config["legend_font_family"] = self.legend_font_family_combo.currentValue()
         config["legend_show_frame"] = self.legend_show_frame_toggle.isChecked()
         config["legend_bg_color"] = self.legend_bg_color_row.currentColor()
         config["legend_bg_alpha"] = self.legend_bg_opacity_slider.value()
@@ -176,6 +185,7 @@ class LegendTab(QWidget):
             self.legend_custom_row.setVisible(legend_position_value == "custom")
             self.legend_font_size_spin.setValue(config.get("legend_font_size", 10))
             self.legend_columns_control.setCurrentValue(config.get("legend_columns", 1))
+            self.legend_font_family_combo.setCurrentValue(config.get("legend_font_family", "DejaVu Sans"))
             self.legend_show_frame_toggle.setChecked(config.get("legend_show_frame", True))
             self.legend_bg_color_row.setCurrentColor(config.get("legend_bg_color", "#ffffff"))
             self.legend_bg_opacity_slider.setValue(config.get("legend_bg_alpha", 1.0))
@@ -189,6 +199,7 @@ class LegendTab(QWidget):
             chart.config["legend_position"] = self.legend_position_combo.currentData()
         chart.config["legend_font_size"] = self.legend_font_size_spin.value()
         chart.config["legend_columns"] = self.legend_columns_control.currentValue()
+        chart.config["legend_font_family"] = self.legend_font_family_combo.currentValue()
         chart.config["legend_show_frame"] = self.legend_show_frame_toggle.isChecked()
         chart.config["legend_bg_color"] = self.legend_bg_color_row.currentColor()
         chart.config["legend_bg_alpha"] = self.legend_bg_opacity_slider.value()
@@ -203,6 +214,7 @@ class LegendTab(QWidget):
         try:
             self.show_legend_toggle.setChecked(True)
             self.legend_columns_control.setCurrentValue(1)
+            self.legend_font_family_combo.setCurrentValue("DejaVu Sans")
             self.legend_show_frame_toggle.setChecked(True)
             self.legend_bg_color_row.setCurrentColor("#ffffff")
             self.legend_bg_opacity_slider.setValue(1.0)

--- a/pandaplot/gui/components/sidebar/chart/tabs/style_tab.py
+++ b/pandaplot/gui/components/sidebar/chart/tabs/style_tab.py
@@ -22,6 +22,7 @@ from pandaplot.gui.components.common.section_header import SectionHeader
 from pandaplot.gui.components.common.slider_with_spinbox import SliderWithSpinbox
 from pandaplot.gui.components.common.toggle_switch import ToggleSwitch
 from pandaplot.gui.components.common.value_combo_box import ValueComboBox
+from pandaplot.gui.components.sidebar.chart.tabs.axes_tab import AXES_SWATCH_PALETTE
 from pandaplot.models.chart.chart_configuration import (
     ChartType,
     LineStyleType,
@@ -38,6 +39,19 @@ from pandaplot.services.config.config_manager import ConfigManager
 
 # Preset swatch palette offered by the Style tab's line/marker color pickers.
 STYLE_SWATCH_PALETTE = ["#1f77b4", "#ff7f0e", "#2ca02c", "#d62728", "#9467bd"]
+
+
+def _make_bold_italic_checks_standalone() -> tuple[QCheckBox, QCheckBox]:
+    """Same as the local closure `_make_bold_italic_checks` defined inside
+    StyleTab.__init__ for the chart-level title/subtitle cards -- extracted
+    as a module-level function so `_build_axis_style_form` (a regular
+    method, outside that closure's scope) can reuse it without
+    duplicating the two-line QCheckBox styling."""
+    bold_check = QCheckBox("Bold")
+    bold_check.setStyleSheet("QCheckBox { font-weight: bold; }")
+    italic_check = QCheckBox("Italic")
+    italic_check.setStyleSheet("QCheckBox { font-style: italic; }")
+    return bold_check, italic_check
 
 
 class StyleTab(QWidget):
@@ -441,6 +455,26 @@ class StyleTab(QWidget):
 
         layout.addWidget(error_bars_card)
 
+        # -- Axes (appearance) section: chart-level, shown only when the
+        # "Chart" chip is selected (same scope as the Font Size/Padding/
+        # Size/DPI cards above) -- axis appearance is a chart-wide concern,
+        # not a per-series one.
+        self.axes_style_selector = ValueComboBox([("X", "x"), ("Y₁", "y")])
+        self.chart_style_cards.append(self.axes_style_selector)
+        layout.addWidget(self.axes_style_selector)
+
+        self._axes_style_form_container = QWidget()
+        self._axes_style_form_container_layout = QVBoxLayout(self._axes_style_form_container)
+        self._axes_style_form_container_layout.setContentsMargins(0, 0, 0, 0)
+        self.chart_style_cards.append(self._axes_style_form_container)
+        layout.addWidget(self._axes_style_form_container)
+
+        self.axes_style_forms = {}
+        for prefix in ("x", "y", "y2"):
+            self._build_axis_style_form(prefix)
+        self._show_axis_style_form("x")
+        self.axes_style_selector.currentValueChanged.connect(self._show_axis_style_form)
+
         layout.addStretch()
         for card in self.chart_style_cards:
             card.setVisible(False)
@@ -539,6 +573,106 @@ class StyleTab(QWidget):
         # chart type (see _is_scatter_series_target), either of which may
         # have just changed.
         self._update_marker_controls_enabled()
+
+    def _build_axis_style_form(self, prefix: str):
+        """Build one axis's appearance form (title font/color, tick-value
+        font/color [Task 6], spine/tick colors [Task 6]) and register it in
+        `self.axes_style_forms[prefix]`."""
+        form_widget = QWidget()
+        form_layout = QVBoxLayout(form_widget)
+        form_layout.setContentsMargins(0, 0, 0, 0)
+
+        title_card = Card()
+        title_layout = QGridLayout(title_card)
+        title_layout.addWidget(SectionHeader("Axis title"), 0, 0, 1, 2)
+
+        title_layout.addWidget(QLabel("Font size:"), 1, 0)
+        font_size_spin = QSpinBox()
+        font_size_spin.setRange(6, 32)
+        font_size_spin.setValue(12)
+        title_layout.addWidget(font_size_spin, 1, 1)
+
+        title_layout.addWidget(QLabel("Font family:"), 2, 0)
+        font_family_combo = ValueComboBox(list_available_font_families())
+        title_layout.addWidget(font_family_combo, 2, 1)
+
+        bold_check, italic_check = _make_bold_italic_checks_standalone()
+        bold_italic_row = QHBoxLayout()
+        bold_italic_row.setContentsMargins(0, 0, 0, 0)
+        bold_italic_row.addWidget(bold_check)
+        bold_italic_row.addWidget(italic_check)
+        bold_italic_row.addStretch(1)
+        bold_italic_widget = QWidget()
+        bold_italic_widget.setLayout(bold_italic_row)
+        title_layout.addWidget(bold_italic_widget, 3, 1)
+
+        color_label = QLabel("Color:")
+        title_layout.addWidget(color_label, 4, 0)
+        color_row = ColorSwatchRow(AXES_SWATCH_PALETTE)
+        title_layout.addWidget(color_row, 4, 1)
+        match_x_toggle = None
+        if prefix in ("y", "y2"):
+            match_x_toggle = ToggleSwitch(checked=True)
+            title_layout.addWidget(QLabel("Match X:"), 4, 2)
+            title_layout.addWidget(match_x_toggle, 4, 3)
+            color_label.setVisible(False)
+            color_row.setVisible(False)
+
+        form_layout.addWidget(title_card)
+
+        self.axes_style_forms[prefix] = {
+            "widget": form_widget, "title_card": title_card,
+            "font_size_spin": font_size_spin, "font_family_combo": font_family_combo,
+            "bold_check": bold_check, "italic_check": italic_check,
+            "color_row": color_row, "color_label": color_label,
+            "match_x_toggle": match_x_toggle,
+        }
+
+        font_size_spin.valueChanged.connect(self._on_chart_style_field_changed)
+        font_family_combo.currentValueChanged.connect(self._on_chart_style_field_changed)
+        bold_check.toggled.connect(self._on_chart_style_field_changed)
+        italic_check.toggled.connect(self._on_chart_style_field_changed)
+        color_row.colorChanged.connect(self._on_chart_style_field_changed)
+        if match_x_toggle is not None:
+            match_x_toggle.toggled.connect(lambda checked, p=prefix: self._on_axis_style_match_x_toggled(p, checked))
+
+        form_widget.setVisible(False)
+        self._axes_style_form_container_layout.addWidget(form_widget)
+
+    def _show_axis_style_form(self, prefix: str):
+        for key, form in self.axes_style_forms.items():
+            form["widget"].setVisible(key == prefix)
+
+    def _on_axis_style_match_x_toggled(self, prefix: str, checked: bool):
+        """Hide the axis-title color swatch while matching X; pre-fill from
+        X's current color the first time it's revealed (mirrors
+        AxesTab._on_match_x_label_toggled)."""
+        form = self.axes_style_forms[prefix]
+        if not checked and not self._updating_controls:
+            form["color_row"].setCurrentColor(self.axes_style_forms["x"]["color_row"].currentColor())
+        form["color_label"].setVisible(not checked)
+        form["color_row"].setVisible(not checked)
+        self._on_chart_style_field_changed()
+
+    def refresh_axis_style_selector(self, chart):
+        """Sync `axes_style_selector`'s Y₂ item with whether any series
+        currently uses the secondary Y axis (mirrors
+        AxesTab.refresh_axis_chips). Safe to call whenever the chart or its
+        series may have changed."""
+        from pandaplot.models.project.items.chart import YAxis
+        has_secondary = bool(chart) and any(
+            series.y_axis == YAxis.SECONDARY for series in chart.data_series
+        )
+        current = self.axes_style_selector.currentValue()
+        self.axes_style_selector.blockSignals(True)
+        self.axes_style_selector.clear()
+        self.axes_style_selector.addItem("X", "x")
+        self.axes_style_selector.addItem("Y₁", "y")
+        if has_secondary:
+            self.axes_style_selector.addItem("Y₂", "y2")
+        restore_index = self.axes_style_selector.findData(current) if current else -1
+        self.axes_style_selector.setCurrentIndex(restore_index if restore_index >= 0 else 0)
+        self.axes_style_selector.blockSignals(False)
 
     def _is_scatter_series_target(self) -> bool:
         """Whether the current target is a data series on a Scatter chart --
@@ -931,6 +1065,23 @@ class StyleTab(QWidget):
                 self._custom_dpi_prefilled = True
             else:
                 self.chart_dpi_combo.setCurrentIndex(self.chart_dpi_combo.count() - 1)
+
+            for prefix in ("x", "y", "y2"):
+                axis_form = self.axes_style_forms[prefix]
+                axis_form["font_size_spin"].setValue(chart.config.get(f"{prefix}_font_size", 12))
+                axis_form["font_family_combo"].setCurrentValue(chart.config.get(f"{prefix}_font_family", "DejaVu Sans"))
+                axis_form["bold_check"].setChecked(chart.config.get(f"{prefix}_title_bold", False))
+                axis_form["italic_check"].setChecked(chart.config.get(f"{prefix}_title_italic", False))
+                match = True
+                if axis_form["match_x_toggle"] is not None:
+                    match = chart.config.get(f"{prefix}_match_x_label_color", True)
+                    axis_form["match_x_toggle"].setChecked(match)
+                axis_form["color_row"].setCurrentColor(chart.config.get(f"{prefix}_label_color", "#000000"))
+                if axis_form["match_x_toggle"] is not None:
+                    axis_form["color_label"].setVisible(not match)
+                    axis_form["color_row"].setVisible(not match)
+            self.refresh_axis_style_selector(chart)
+            self._show_axis_style_form(self.axes_style_selector.currentValue() or "x")
         finally:
             self._updating_controls = previous_guard
 
@@ -962,6 +1113,16 @@ class StyleTab(QWidget):
         )
         chart.config["width_cm"], chart.config["height_cm"] = self._size_from_controls()
         chart.config["dpi"] = self._dpi_from_controls()
+
+        for prefix in ("x", "y", "y2"):
+            axis_form = self.axes_style_forms[prefix]
+            chart.config[f"{prefix}_font_size"] = axis_form["font_size_spin"].value()
+            chart.config[f"{prefix}_font_family"] = axis_form["font_family_combo"].currentValue()
+            chart.config[f"{prefix}_title_bold"] = axis_form["bold_check"].isChecked()
+            chart.config[f"{prefix}_title_italic"] = axis_form["italic_check"].isChecked()
+            chart.config[f"{prefix}_label_color"] = axis_form["color_row"].currentColor()
+            if axis_form["match_x_toggle"] is not None:
+                chart.config[f"{prefix}_match_x_label_color"] = axis_form["match_x_toggle"].isChecked()
 
     def clear_chart_style(self):
         self._chart = None
@@ -999,6 +1160,17 @@ class StyleTab(QWidget):
             self.chart_dpi_combo.setCurrentIndex(self.chart_dpi_combo.count() - 1)
             self.chart_dpi_spin.setValue(100)
             self._custom_dpi_prefilled = False
+
+            for prefix in ("x", "y", "y2"):
+                axis_form = self.axes_style_forms[prefix]
+                axis_form["font_size_spin"].setValue(12)
+                axis_form["font_family_combo"].setCurrentValue("DejaVu Sans")
+                axis_form["bold_check"].setChecked(False)
+                axis_form["italic_check"].setChecked(False)
+                axis_form["color_row"].setCurrentColor("#000000")
+                if axis_form["match_x_toggle"] is not None:
+                    axis_form["match_x_toggle"].setChecked(True)
+            self.refresh_axis_style_selector(None)
         finally:
             self._updating_controls = previous_guard
 
@@ -1104,6 +1276,16 @@ class StyleTab(QWidget):
         )
         config["width_cm"], config["height_cm"] = self._size_from_controls()
         config["dpi"] = self._dpi_from_controls()
+
+        for prefix in ("x", "y", "y2"):
+            axis_form = self.axes_style_forms[prefix]
+            config[f"{prefix}_font_size"] = axis_form["font_size_spin"].value()
+            config[f"{prefix}_font_family"] = axis_form["font_family_combo"].currentValue()
+            config[f"{prefix}_title_bold"] = axis_form["bold_check"].isChecked()
+            config[f"{prefix}_title_italic"] = axis_form["italic_check"].isChecked()
+            config[f"{prefix}_label_color"] = axis_form["color_row"].currentColor()
+            if axis_form["match_x_toggle"] is not None:
+                config[f"{prefix}_match_x_label_color"] = axis_form["match_x_toggle"].isChecked()
         self.configChanged.emit()
 
     # -- Theme ----------------------------------------------------------------
@@ -1135,3 +1317,9 @@ class StyleTab(QWidget):
         self.figure_bg_transparent_toggle.set_tokens(tokens)
         self.axes_bg_color_row.set_tokens(tokens)
         self.axes_bg_transparent_toggle.set_tokens(tokens)
+        self.axes_style_selector.set_tokens(tokens)
+        for form in self.axes_style_forms.values():
+            form["title_card"].set_tokens(tokens)
+            form["color_row"].set_tokens(tokens)
+            if form["match_x_toggle"] is not None:
+                form["match_x_toggle"].set_tokens(tokens)

--- a/pandaplot/gui/components/sidebar/chart/tabs/style_tab.py
+++ b/pandaplot/gui/components/sidebar/chart/tabs/style_tab.py
@@ -825,6 +825,13 @@ class StyleTab(QWidget):
         restore_index = self.axes_style_selector.findData(current) if current else -1
         self.axes_style_selector.setCurrentIndex(restore_index if restore_index >= 0 else 0)
         self.axes_style_selector.blockSignals(False)
+        # setCurrentIndex() above ran with signals blocked (so rebuilding the
+        # combo's items doesn't spuriously emit currentValueChanged), which
+        # means _show_axis_style_form never fires if the selection was just
+        # forced back to "X" (e.g. the last Y2 series was removed while Y2
+        # was selected) -- the Y2 form would stay visible while the combo now
+        # reads "X". Drive it explicitly so the visible form always matches.
+        self._show_axis_style_form(self.axes_style_selector.currentValue() or "x")
 
     def _is_scatter_series_target(self) -> bool:
         """Whether the current target is a data series on a Scatter chart --

--- a/pandaplot/gui/components/sidebar/chart/tabs/style_tab.py
+++ b/pandaplot/gui/components/sidebar/chart/tabs/style_tab.py
@@ -16,6 +16,7 @@ from PySide6.QtWidgets import (
 
 from pandaplot.gui.components.common.card import Card
 from pandaplot.gui.components.common.color_swatch_row import ColorSwatchRow
+from pandaplot.gui.components.common.font_family_options import list_available_font_families
 from pandaplot.gui.components.common.line_style_icons import build_line_style_icon
 from pandaplot.gui.components.common.section_header import SectionHeader
 from pandaplot.gui.components.common.slider_with_spinbox import SliderWithSpinbox
@@ -141,28 +142,34 @@ class StyleTab(QWidget):
             _bold_italic_widget(self.title_bold_check, self.title_italic_check), 2, 1,
         )
 
+        self.title_font_family_combo = ValueComboBox(list_available_font_families())
+        _field_row(font_size_layout, 3, "Title font", self.title_font_family_combo)
+
         self.subtitle_font_size_spin = QSpinBox()
         self.subtitle_font_size_spin.setRange(8, 32)
         self.subtitle_font_size_spin.setValue(12)
-        _field_row(font_size_layout, 3, "Subtitle", self.subtitle_font_size_spin)
+        _field_row(font_size_layout, 4, "Subtitle", self.subtitle_font_size_spin)
         self.subtitle_bold_check, self.subtitle_italic_check = _make_bold_italic_checks()
         font_size_layout.addWidget(
-            _bold_italic_widget(self.subtitle_bold_check, self.subtitle_italic_check), 4, 1,
+            _bold_italic_widget(self.subtitle_bold_check, self.subtitle_italic_check), 5, 1,
         )
 
-        # -- Title/subtitle color (rows 5-7, appended after the existing
-        # title/subtitle font-size/bold/italic rows above to avoid
-        # renumbering them) --
+        self.subtitle_font_family_combo = ValueComboBox(list_available_font_families())
+        _field_row(font_size_layout, 6, "Subtitle font", self.subtitle_font_family_combo)
+
+        # -- Title/subtitle color (rows 7-9, appended after the existing
+        # title/subtitle font-size/bold/italic/font-family rows above to
+        # avoid renumbering them) --
         self.title_color_row = ColorSwatchRow(STYLE_SWATCH_PALETTE)
-        font_size_layout.addWidget(QLabel("Title color:"), 5, 0)
-        font_size_layout.addWidget(self.title_color_row, 5, 1)
+        font_size_layout.addWidget(QLabel("Title color:"), 7, 0)
+        font_size_layout.addWidget(self.title_color_row, 7, 1)
 
         self.subtitle_color_row = ColorSwatchRow(STYLE_SWATCH_PALETTE)
         self.subtitle_match_title_toggle = ToggleSwitch(checked=True)
-        font_size_layout.addWidget(QLabel("Subtitle color:"), 6, 0)
-        font_size_layout.addWidget(self.subtitle_color_row, 6, 1)
-        font_size_layout.addWidget(QLabel("Match title:"), 7, 0)
-        font_size_layout.addWidget(self.subtitle_match_title_toggle, 7, 1)
+        font_size_layout.addWidget(QLabel("Subtitle color:"), 8, 0)
+        font_size_layout.addWidget(self.subtitle_color_row, 8, 1)
+        font_size_layout.addWidget(QLabel("Match title:"), 9, 0)
+        font_size_layout.addWidget(self.subtitle_match_title_toggle, 9, 1)
         # Hidden by default: subtitle_match_title_toggle starts checked, so
         # the subtitle color swatch (which would otherwise be redundant with
         # the title's) stays hidden until the user opts out of matching.
@@ -470,6 +477,8 @@ class StyleTab(QWidget):
         self.subtitle_italic_check.toggled.connect(self._on_chart_style_field_changed)
         self.title_color_row.colorChanged.connect(self._on_chart_style_field_changed)
         self.subtitle_color_row.colorChanged.connect(self._on_chart_style_field_changed)
+        self.title_font_family_combo.currentValueChanged.connect(self._on_chart_style_field_changed)
+        self.subtitle_font_family_combo.currentValueChanged.connect(self._on_chart_style_field_changed)
         self.subtitle_match_title_toggle.toggled.connect(self._on_subtitle_match_title_toggled)
         self.chart_size_combo.currentIndexChanged.connect(self._on_chart_size_combo_changed)
         self.chart_dpi_combo.currentIndexChanged.connect(self._on_chart_dpi_combo_changed)
@@ -857,6 +866,10 @@ class StyleTab(QWidget):
         try:
             self.title_font_size_spin.setValue(chart.config.get("title_font_size", 14))
             self.subtitle_font_size_spin.setValue(chart.config.get("subtitle_font_size", 12))
+            self.title_font_family_combo.setCurrentValue(chart.config.get("title_font_family", "DejaVu Sans"))
+            self.subtitle_font_family_combo.setCurrentValue(
+                chart.config.get("subtitle_font_family", "DejaVu Sans")
+            )
             self.chart_padding_spin.setValue(chart.config.get("chart_padding", 2.0))
             self.chart_padding_w_spin.setValue(chart.config.get("chart_padding_w", 2.0))
             self.chart_padding_h_spin.setValue(chart.config.get("chart_padding_h", 2.0))
@@ -924,6 +937,8 @@ class StyleTab(QWidget):
     def apply_chart_style_to(self, chart):
         chart.config["title_font_size"] = self.title_font_size_spin.value()
         chart.config["subtitle_font_size"] = self.subtitle_font_size_spin.value()
+        chart.config["title_font_family"] = self.title_font_family_combo.currentValue()
+        chart.config["subtitle_font_family"] = self.subtitle_font_family_combo.currentValue()
         chart.config["chart_padding"] = self.chart_padding_spin.value()
         chart.config["chart_padding_w"] = self.chart_padding_w_spin.value()
         chart.config["chart_padding_h"] = self.chart_padding_h_spin.value()
@@ -955,6 +970,8 @@ class StyleTab(QWidget):
         try:
             self.title_font_size_spin.setValue(14)
             self.subtitle_font_size_spin.setValue(12)
+            self.title_font_family_combo.setCurrentValue("DejaVu Sans")
+            self.subtitle_font_family_combo.setCurrentValue("DejaVu Sans")
             self.chart_padding_spin.setValue(2.0)
             self.chart_padding_w_spin.setValue(2.0)
             self.chart_padding_h_spin.setValue(2.0)
@@ -1062,6 +1079,8 @@ class StyleTab(QWidget):
         config = self._chart.config
         config["title_font_size"] = self.title_font_size_spin.value()
         config["subtitle_font_size"] = self.subtitle_font_size_spin.value()
+        config["title_font_family"] = self.title_font_family_combo.currentValue()
+        config["subtitle_font_family"] = self.subtitle_font_family_combo.currentValue()
         config["chart_padding"] = self.chart_padding_spin.value()
         config["chart_padding_w"] = self.chart_padding_w_spin.value()
         config["chart_padding_h"] = self.chart_padding_h_spin.value()

--- a/pandaplot/gui/components/sidebar/chart/tabs/style_tab.py
+++ b/pandaplot/gui/components/sidebar/chart/tabs/style_tab.py
@@ -9,6 +9,7 @@ from PySide6.QtWidgets import (
     QGridLayout,
     QHBoxLayout,
     QLabel,
+    QPushButton,
     QSpinBox,
     QVBoxLayout,
     QWidget,
@@ -620,12 +621,86 @@ class StyleTab(QWidget):
 
         form_layout.addWidget(title_card)
 
+        ticks_card = Card()
+        ticks_layout = QGridLayout(ticks_card)
+        ticks_layout.addWidget(SectionHeader("Tick values"), 0, 0, 1, 2)
+
+        ticks_layout.addWidget(QLabel("Font size:"), 1, 0)
+        tick_font_size_spin = QSpinBox()
+        tick_font_size_spin.setRange(6, 32)
+        tick_font_size_spin.setValue(10)
+        ticks_layout.addWidget(tick_font_size_spin, 1, 1)
+
+        ticks_layout.addWidget(QLabel("Font family:"), 2, 0)
+        tick_font_family_combo = ValueComboBox(list_available_font_families())
+        ticks_layout.addWidget(tick_font_family_combo, 2, 1)
+
+        tick_bold_check, tick_italic_check = _make_bold_italic_checks_standalone()
+        tick_bold_italic_row = QHBoxLayout()
+        tick_bold_italic_row.setContentsMargins(0, 0, 0, 0)
+        tick_bold_italic_row.addWidget(tick_bold_check)
+        tick_bold_italic_row.addWidget(tick_italic_check)
+        tick_bold_italic_row.addStretch(1)
+        tick_bold_italic_widget = QWidget()
+        tick_bold_italic_widget.setLayout(tick_bold_italic_row)
+        ticks_layout.addWidget(tick_bold_italic_widget, 3, 1)
+
+        ticks_layout.addWidget(QLabel("Color:"), 4, 0)
+        tick_color_row = ColorSwatchRow(AXES_SWATCH_PALETTE)
+        ticks_layout.addWidget(tick_color_row, 4, 1)
+
+        form_layout.addWidget(ticks_card)
+
+        colors_card = Card()
+        colors_layout = QGridLayout(colors_card)
+        colors_layout.addWidget(SectionHeader("Colors"), 0, 0, 1, 2)
+
+        colors_layout.addWidget(QLabel("Spine:"), 1, 0)
+        spine_color_row = ColorSwatchRow(AXES_SWATCH_PALETTE)
+        colors_layout.addWidget(spine_color_row, 1, 1)
+
+        colors_layout.addWidget(QLabel("Major ticks:"), 2, 0)
+        major_tick_color_row = ColorSwatchRow(AXES_SWATCH_PALETTE)
+        colors_layout.addWidget(major_tick_color_row, 2, 1)
+
+        minor_tick_color_label = QLabel("Minor ticks:")
+        colors_layout.addWidget(minor_tick_color_label, 3, 0)
+        minor_tick_color_row = ColorSwatchRow(AXES_SWATCH_PALETTE)
+        colors_layout.addWidget(minor_tick_color_row, 3, 1)
+
+        match_x_colors_toggle = None
+        if prefix in ("y", "y2"):
+            match_x_colors_toggle = ToggleSwitch(checked=True)
+            colors_layout.addWidget(QLabel("Match X:"), 4, 0)
+            colors_layout.addWidget(match_x_colors_toggle, 4, 1)
+
+        form_layout.addWidget(colors_card)
+
+        copy_button = None
+        if prefix in ("y", "y2"):
+            copy_button = QPushButton("Copy style to Y axis")
+            copy_button.setFlat(True)
+            copy_button.clicked.connect(lambda _checked=False, p=prefix: self._on_copy_axis_style(p))
+            form_layout.addWidget(copy_button)
+
         self.axes_style_forms[prefix] = {
             "widget": form_widget, "title_card": title_card,
             "font_size_spin": font_size_spin, "font_family_combo": font_family_combo,
             "bold_check": bold_check, "italic_check": italic_check,
             "color_row": color_row, "color_label": color_label,
             "match_x_toggle": match_x_toggle,
+            "ticks_card": ticks_card,
+            "tick_font_size_spin": tick_font_size_spin,
+            "tick_font_family_combo": tick_font_family_combo,
+            "tick_bold_check": tick_bold_check, "tick_italic_check": tick_italic_check,
+            "tick_color_row": tick_color_row,
+            "colors_card": colors_card,
+            "spine_color_row": spine_color_row,
+            "major_tick_color_row": major_tick_color_row,
+            "minor_tick_color_row": minor_tick_color_row,
+            "minor_tick_color_label": minor_tick_color_label,
+            "match_x_colors_toggle": match_x_colors_toggle,
+            "copy_button": copy_button,
         }
 
         font_size_spin.valueChanged.connect(self._on_chart_style_field_changed)
@@ -635,6 +710,18 @@ class StyleTab(QWidget):
         color_row.colorChanged.connect(self._on_chart_style_field_changed)
         if match_x_toggle is not None:
             match_x_toggle.toggled.connect(lambda checked, p=prefix: self._on_axis_style_match_x_toggled(p, checked))
+
+        tick_font_size_spin.valueChanged.connect(self._on_chart_style_field_changed)
+        tick_font_family_combo.currentValueChanged.connect(self._on_chart_style_field_changed)
+        tick_bold_check.toggled.connect(self._on_chart_style_field_changed)
+        tick_italic_check.toggled.connect(self._on_chart_style_field_changed)
+        tick_color_row.colorChanged.connect(self._on_chart_style_field_changed)
+        spine_color_row.colorChanged.connect(self._on_chart_style_field_changed)
+        major_tick_color_row.colorChanged.connect(self._on_chart_style_field_changed)
+        minor_tick_color_row.colorChanged.connect(self._on_chart_style_field_changed)
+        if match_x_colors_toggle is not None:
+            match_x_colors_toggle.toggled.connect(
+                lambda checked, p=prefix: self._on_axis_style_match_x_colors_toggled(p, checked))
 
         form_widget.setVisible(False)
         self._axes_style_form_container_layout.addWidget(form_widget)
@@ -652,6 +739,71 @@ class StyleTab(QWidget):
             form["color_row"].setCurrentColor(self.axes_style_forms["x"]["color_row"].currentColor())
         form["color_label"].setVisible(not checked)
         form["color_row"].setVisible(not checked)
+        self._on_chart_style_field_changed()
+
+    def _on_axis_style_match_x_colors_toggled(self, prefix: str, checked: bool):
+        """Mirrors AxesTab._on_match_x_colors_toggled, for the Style tab's
+        Colors card (spine/major/minor tick colors).
+
+        Unlike AxesTab's equivalent, minor-tick-color visibility here is
+        gated only by the Match-X toggle, not additionally by "are minor
+        ticks enabled" -- that state lives in the Axes tab, not this form;
+        showing the minor-tick-color picker here even when minor ticks
+        happen to be off is harmless, since it just sets a color that has
+        no effect until minor ticks are turned on elsewhere.
+        """
+        form = self.axes_style_forms[prefix]
+        x_form = self.axes_style_forms["x"]
+        if not checked and not self._updating_controls:
+            form["spine_color_row"].setCurrentColor(x_form["spine_color_row"].currentColor())
+            form["major_tick_color_row"].setCurrentColor(x_form["major_tick_color_row"].currentColor())
+            form["minor_tick_color_row"].setCurrentColor(x_form["minor_tick_color_row"].currentColor())
+            form["tick_color_row"].setCurrentColor(x_form["tick_color_row"].currentColor())
+        for widget_key in ("spine_color_row", "major_tick_color_row", "tick_color_row"):
+            form[widget_key].setVisible(not checked)
+        form["minor_tick_color_row"].setVisible(not checked)
+        form["minor_tick_color_label"].setVisible(not checked)
+        self._on_chart_style_field_changed()
+
+    def _on_copy_axis_style(self, prefix: str):
+        """Copy the shown Y axis's appearance fields (font/color, tick
+        font/color, spine/tick colors) to the other Y axis. Mirrors
+        AxesTab._on_copy_axis_settings, scoped to this tab's own fields."""
+        other = "y2" if prefix == "y" else "y"
+        source = self.axes_style_forms[prefix]
+        target = self.axes_style_forms[other]
+
+        target["font_size_spin"].setValue(source["font_size_spin"].value())
+        target["font_family_combo"].setCurrentValue(source["font_family_combo"].currentValue())
+        target["bold_check"].setChecked(source["bold_check"].isChecked())
+        target["italic_check"].setChecked(source["italic_check"].isChecked())
+        target["tick_font_size_spin"].setValue(source["tick_font_size_spin"].value())
+        target["tick_font_family_combo"].setCurrentValue(source["tick_font_family_combo"].currentValue())
+        target["tick_bold_check"].setChecked(source["tick_bold_check"].isChecked())
+        target["tick_italic_check"].setChecked(source["tick_italic_check"].isChecked())
+
+        # Match-X toggles MUST be set before the color swatches they gate
+        # (see AxesTab._on_copy_axis_settings for why: setChecked fires
+        # toggled unconditionally, and the handler pre-fills from X's
+        # *current* color whenever set to "not matching").
+        if source["match_x_toggle"] is not None and target["match_x_toggle"] is not None:
+            target["match_x_toggle"].setChecked(source["match_x_toggle"].isChecked())
+        if source["match_x_colors_toggle"] is not None and target["match_x_colors_toggle"] is not None:
+            target["match_x_colors_toggle"].setChecked(source["match_x_colors_toggle"].isChecked())
+
+        target["color_row"].setCurrentColor(source["color_row"].currentColor())
+        target["tick_color_row"].setCurrentColor(source["tick_color_row"].currentColor())
+        target["spine_color_row"].setCurrentColor(source["spine_color_row"].currentColor())
+        target["major_tick_color_row"].setCurrentColor(source["major_tick_color_row"].currentColor())
+        target["minor_tick_color_row"].setCurrentColor(source["minor_tick_color_row"].currentColor())
+
+        target["color_label"].setVisible(not target["match_x_toggle"].isChecked())
+        target["color_row"].setVisible(not target["match_x_toggle"].isChecked())
+        matching_colors = target["match_x_colors_toggle"].isChecked()
+        for widget_key in ("spine_color_row", "major_tick_color_row", "tick_color_row", "minor_tick_color_row"):
+            target[widget_key].setVisible(not matching_colors)
+        target["minor_tick_color_label"].setVisible(not matching_colors)
+
         self._on_chart_style_field_changed()
 
     def refresh_axis_style_selector(self, chart):
@@ -1080,6 +1232,27 @@ class StyleTab(QWidget):
                 if axis_form["match_x_toggle"] is not None:
                     axis_form["color_label"].setVisible(not match)
                     axis_form["color_row"].setVisible(not match)
+
+                axis_form["tick_font_size_spin"].setValue(chart.config.get(f"{prefix}_tick_label_font_size", 10))
+                axis_form["tick_font_family_combo"].setCurrentValue(
+                    chart.config.get(f"{prefix}_tick_label_font_family", "DejaVu Sans"))
+                axis_form["tick_bold_check"].setChecked(chart.config.get(f"{prefix}_tick_label_bold", False))
+                axis_form["tick_italic_check"].setChecked(chart.config.get(f"{prefix}_tick_label_italic", False))
+                axis_form["tick_color_row"].setCurrentColor(chart.config.get(f"{prefix}_tick_label_color", "#000000"))
+                match_colors = True
+                if axis_form["match_x_colors_toggle"] is not None:
+                    match_colors = chart.config.get(f"{prefix}_match_x_colors", True)
+                    axis_form["match_x_colors_toggle"].setChecked(match_colors)
+                axis_form["spine_color_row"].setCurrentColor(chart.config.get(f"{prefix}_spine_color", "#000000"))
+                axis_form["major_tick_color_row"].setCurrentColor(
+                    chart.config.get(f"{prefix}_major_tick_color", "#000000"))
+                axis_form["minor_tick_color_row"].setCurrentColor(
+                    chart.config.get(f"{prefix}_minor_tick_color", "#000000"))
+                if axis_form["match_x_colors_toggle"] is not None:
+                    for widget_key in ("spine_color_row", "major_tick_color_row", "tick_color_row",
+                                       "minor_tick_color_row"):
+                        axis_form[widget_key].setVisible(not match_colors)
+                    axis_form["minor_tick_color_label"].setVisible(not match_colors)
             self.refresh_axis_style_selector(chart)
             self._show_axis_style_form(self.axes_style_selector.currentValue() or "x")
         finally:
@@ -1123,6 +1296,16 @@ class StyleTab(QWidget):
             chart.config[f"{prefix}_label_color"] = axis_form["color_row"].currentColor()
             if axis_form["match_x_toggle"] is not None:
                 chart.config[f"{prefix}_match_x_label_color"] = axis_form["match_x_toggle"].isChecked()
+            chart.config[f"{prefix}_tick_label_font_size"] = axis_form["tick_font_size_spin"].value()
+            chart.config[f"{prefix}_tick_label_font_family"] = axis_form["tick_font_family_combo"].currentValue()
+            chart.config[f"{prefix}_tick_label_bold"] = axis_form["tick_bold_check"].isChecked()
+            chart.config[f"{prefix}_tick_label_italic"] = axis_form["tick_italic_check"].isChecked()
+            chart.config[f"{prefix}_tick_label_color"] = axis_form["tick_color_row"].currentColor()
+            chart.config[f"{prefix}_spine_color"] = axis_form["spine_color_row"].currentColor()
+            chart.config[f"{prefix}_major_tick_color"] = axis_form["major_tick_color_row"].currentColor()
+            chart.config[f"{prefix}_minor_tick_color"] = axis_form["minor_tick_color_row"].currentColor()
+            if axis_form["match_x_colors_toggle"] is not None:
+                chart.config[f"{prefix}_match_x_colors"] = axis_form["match_x_colors_toggle"].isChecked()
 
     def clear_chart_style(self):
         self._chart = None
@@ -1170,6 +1353,16 @@ class StyleTab(QWidget):
                 axis_form["color_row"].setCurrentColor("#000000")
                 if axis_form["match_x_toggle"] is not None:
                     axis_form["match_x_toggle"].setChecked(True)
+                axis_form["tick_font_size_spin"].setValue(10)
+                axis_form["tick_font_family_combo"].setCurrentValue("DejaVu Sans")
+                axis_form["tick_bold_check"].setChecked(False)
+                axis_form["tick_italic_check"].setChecked(False)
+                axis_form["tick_color_row"].setCurrentColor("#000000")
+                axis_form["spine_color_row"].setCurrentColor("#000000")
+                axis_form["major_tick_color_row"].setCurrentColor("#000000")
+                axis_form["minor_tick_color_row"].setCurrentColor("#000000")
+                if axis_form["match_x_colors_toggle"] is not None:
+                    axis_form["match_x_colors_toggle"].setChecked(True)
             self.refresh_axis_style_selector(None)
         finally:
             self._updating_controls = previous_guard
@@ -1286,6 +1479,16 @@ class StyleTab(QWidget):
             config[f"{prefix}_label_color"] = axis_form["color_row"].currentColor()
             if axis_form["match_x_toggle"] is not None:
                 config[f"{prefix}_match_x_label_color"] = axis_form["match_x_toggle"].isChecked()
+            config[f"{prefix}_tick_label_font_size"] = axis_form["tick_font_size_spin"].value()
+            config[f"{prefix}_tick_label_font_family"] = axis_form["tick_font_family_combo"].currentValue()
+            config[f"{prefix}_tick_label_bold"] = axis_form["tick_bold_check"].isChecked()
+            config[f"{prefix}_tick_label_italic"] = axis_form["tick_italic_check"].isChecked()
+            config[f"{prefix}_tick_label_color"] = axis_form["tick_color_row"].currentColor()
+            config[f"{prefix}_spine_color"] = axis_form["spine_color_row"].currentColor()
+            config[f"{prefix}_major_tick_color"] = axis_form["major_tick_color_row"].currentColor()
+            config[f"{prefix}_minor_tick_color"] = axis_form["minor_tick_color_row"].currentColor()
+            if axis_form["match_x_colors_toggle"] is not None:
+                config[f"{prefix}_match_x_colors"] = axis_form["match_x_colors_toggle"].isChecked()
         self.configChanged.emit()
 
     # -- Theme ----------------------------------------------------------------
@@ -1323,3 +1526,11 @@ class StyleTab(QWidget):
             form["color_row"].set_tokens(tokens)
             if form["match_x_toggle"] is not None:
                 form["match_x_toggle"].set_tokens(tokens)
+            form["ticks_card"].set_tokens(tokens)
+            form["tick_color_row"].set_tokens(tokens)
+            form["colors_card"].set_tokens(tokens)
+            form["spine_color_row"].set_tokens(tokens)
+            form["major_tick_color_row"].set_tokens(tokens)
+            form["minor_tick_color_row"].set_tokens(tokens)
+            if form["match_x_colors_toggle"] is not None:
+                form["match_x_colors_toggle"].set_tokens(tokens)

--- a/pandaplot/gui/components/sidebar/chart/tabs/style_tab.py
+++ b/pandaplot/gui/components/sidebar/chart/tabs/style_tab.py
@@ -105,7 +105,7 @@ class StyleTab(QWidget):
 
         layout = QVBoxLayout(self)
 
-        self.style_series_chips = ValueComboBox([("Chart", "chart")])
+        self.style_series_chips = ValueComboBox([("Chart", "chart"), ("Axes", "axes")])
         self.style_series_chips.currentValueChanged.connect(self._on_chip_selected)
         layout.addWidget(self.style_series_chips)
 
@@ -456,18 +456,19 @@ class StyleTab(QWidget):
 
         layout.addWidget(error_bars_card)
 
-        # -- Axes (appearance) section: chart-level, shown only when the
-        # "Chart" chip is selected (same scope as the Font Size/Padding/
-        # Size/DPI cards above) -- axis appearance is a chart-wide concern,
-        # not a per-series one.
+        # -- Axes (appearance) section: its own top-level selection in
+        # style_series_chips (sibling to "Chart"/series/fit), not nested
+        # under "Chart" -- axis appearance is a chart-wide concern like the
+        # Font Size/Padding/Size/DPI cards above, but gets its own entry in
+        # the selector rather than being folded into "Chart"'s cards.
         self.axes_style_selector = ValueComboBox([("X", "x"), ("Y₁", "y")])
-        self.chart_style_cards.append(self.axes_style_selector)
+        self.axes_style_widgets: list[QWidget] = [self.axes_style_selector]
         layout.addWidget(self.axes_style_selector)
 
         self._axes_style_form_container = QWidget()
         self._axes_style_form_container_layout = QVBoxLayout(self._axes_style_form_container)
         self._axes_style_form_container_layout.setContentsMargins(0, 0, 0, 0)
-        self.chart_style_cards.append(self._axes_style_form_container)
+        self.axes_style_widgets.append(self._axes_style_form_container)
         layout.addWidget(self._axes_style_form_container)
 
         self.axes_style_forms = {}
@@ -479,6 +480,8 @@ class StyleTab(QWidget):
         layout.addStretch()
         for card in self.chart_style_cards:
             card.setVisible(False)
+        for widget in self.axes_style_widgets:
+            widget.setVisible(False)
 
         # Series/fit style field connections.
         self.line_color_row.colorChanged.connect(self._on_field_changed)
@@ -531,6 +534,9 @@ class StyleTab(QWidget):
         if value == "chart":
             self._current_target = ("chart", None)
             self._update_target_cards_visibility()
+        elif value == "axes":
+            self._current_target = ("axes", None)
+            self._update_target_cards_visibility()
         elif value is not None:
             # The panel (until Task 5) or DataTab (after Task 5) is the
             # source of truth for series/fit selection -- this tab does not
@@ -560,6 +566,9 @@ class StyleTab(QWidget):
         is_chart = kind == "chart"
         for card in self.chart_style_cards:
             card.setVisible(is_chart)
+        is_axes = kind == "axes"
+        for widget in self.axes_style_widgets:
+            widget.setVisible(is_axes)
         is_scatter = self._chart_type == ChartType.SCATTER
         self.line_card.setVisible(kind == "fit" or (kind == "series" and not is_scatter))
         self.marker_card.setVisible(kind == "series")
@@ -886,7 +895,7 @@ class StyleTab(QWidget):
         reflexive reassignments correctly.
         """
         previous_value = self.style_series_chips.currentValue()
-        chip_items = [("Chart", "chart")]
+        chip_items = [("Chart", "chart"), ("Axes", "axes")]
         for index, series in enumerate(data_series):
             label = series.label or f"{series.dataset_id}:{self._series_y_name(series)}"
             chip_items.append((label, index))
@@ -911,8 +920,8 @@ class StyleTab(QWidget):
         # from, so it must not count as "initialized" either, or it would
         # make the *next* call's placeholder "chart" look like a genuine
         # prior selection).
-        if self._series_list_initialized and previous_value == "chart":
-            self.style_series_chips.setCurrentValue("chart")
+        if self._series_list_initialized and previous_value in ("chart", "axes"):
+            self.style_series_chips.setCurrentValue(previous_value)
         else:
             self.style_series_chips.setCurrentValue(selected_index)
         if data_series or fit_data:
@@ -921,6 +930,9 @@ class StyleTab(QWidget):
         final_value = self.style_series_chips.currentValue()
         if final_value == "chart":
             self._current_target = ("chart", None)
+            self._update_target_cards_visibility()
+        elif final_value == "axes":
+            self._current_target = ("axes", None)
             self._update_target_cards_visibility()
         elif final_value < len(data_series):
             self.set_selected("series", data_series[final_value])

--- a/pandaplot/gui/components/tabs/chart/chart_editor.py
+++ b/pandaplot/gui/components/tabs/chart/chart_editor.py
@@ -246,6 +246,27 @@ def apply_spine_colors(axes, axes2, x_color, y_color, y2_color):
         axes2.spines["right"].set_color(y2_color)
 
 
+_OUTSIDE_LEGEND_PLACEMENTS = {
+    "outside_right": ("center left", (1.02, 0.5)),
+    "outside_top": ("lower center", (0.5, 1.02)),
+    "outside_bottom": ("upper center", (0.5, -0.08)),
+}
+
+
+def resolve_legend_placement(position: str, custom_x: float, custom_y: float, custom_anchor: str) -> dict:
+    """Map a `legend_position` config value to matplotlib Legend kwargs.
+    Existing inside positions (matplotlib `loc` strings, e.g. "upper
+    right") pass through as `loc` only, unchanged. The three outside
+    presets use a fixed `loc`/`bbox_to_anchor` pair. "custom" uses the
+    user-supplied anchor corner and x/y (both 0-1, relative to the axes)."""
+    if position in _OUTSIDE_LEGEND_PLACEMENTS:
+        loc, bbox_to_anchor = _OUTSIDE_LEGEND_PLACEMENTS[position]
+        return {"loc": loc, "bbox_to_anchor": bbox_to_anchor}
+    if position == "custom":
+        return {"loc": custom_anchor, "bbox_to_anchor": (custom_x, custom_y)}
+    return {"loc": position}
+
+
 def _resolve_error_column(df, column_name):
     """Best-effort lookup of an optional error column.
 
@@ -1022,14 +1043,20 @@ class ChartEditorWidget(PWidget):
                     handles2, labels2 = self.chart_canvas.axes2.get_legend_handles_labels()
                     handles += handles2
                     labels += labels2
+                placement_kwargs = resolve_legend_placement(
+                    config.get("legend_position", "upper right"),
+                    config.get("legend_custom_x", 1.02),
+                    config.get("legend_custom_y", 0.5),
+                    config.get("legend_custom_anchor", "center left"),
+                )
                 self.chart_canvas.axes.legend(
                     handles, labels,
-                    loc=config.get("legend_position", "upper right"),
                     fontsize=config.get("legend_font_size", 10),
                     facecolor=config.get("legend_bg_color", "#ffffff"),
                     frameon=config.get("legend_show_frame", True),
                     ncol=config.get("legend_columns", 1),
-                    framealpha=config.get("legend_bg_alpha", 1.0))
+                    framealpha=config.get("legend_bg_alpha", 1.0),
+                    **placement_kwargs)
 
             if self.chart_canvas.axes2 is not None:
                 # Reserve room for the secondary axis label/ticks so they

--- a/pandaplot/gui/components/tabs/chart/chart_editor.py
+++ b/pandaplot/gui/components/tabs/chart/chart_editor.py
@@ -55,6 +55,8 @@ def apply_chart_title(
     subtitle_italic: bool = False,
     title_color: str = "#000000",
     subtitle_color: str = "#000000",
+    title_font_family: str = "DejaVu Sans",
+    subtitle_font_family: str = "DejaVu Sans",
 ) -> None:
     """Render the title (figure-level) and subtitle (axes-level) as two
     independent Matplotlib Text artists so each can have its own font size
@@ -89,6 +91,7 @@ def apply_chart_title(
             fontweight="bold" if title_bold else "normal",
             fontstyle="italic" if title_italic else "normal",
             color=title_color,
+            fontfamily=title_font_family,
         )
     elif fig._suptitle is not None:
         fig._suptitle.set_text("")
@@ -98,6 +101,7 @@ def apply_chart_title(
         fontweight="bold" if subtitle_bold else "normal",
         fontstyle="italic" if subtitle_italic else "normal",
         color=subtitle_color,
+        fontfamily=subtitle_font_family,
     )
 
 
@@ -745,6 +749,8 @@ class ChartEditorWidget(PWidget):
                     if config.get("subtitle_match_title_color", True)
                     else config.get("subtitle_color", "#000000")
                 ),
+                title_font_family=config.get("title_font_family", "DejaVu Sans"),
+                subtitle_font_family=config.get("subtitle_font_family", "DejaVu Sans"),
             )
 
             chart_padding = config.get("chart_padding", 2.0)

--- a/pandaplot/gui/components/tabs/chart/chart_editor.py
+++ b/pandaplot/gui/components/tabs/chart/chart_editor.py
@@ -1056,6 +1056,7 @@ class ChartEditorWidget(PWidget):
                     frameon=config.get("legend_show_frame", True),
                     ncol=config.get("legend_columns", 1),
                     framealpha=config.get("legend_bg_alpha", 1.0),
+                    prop={"family": config.get("legend_font_family", "DejaVu Sans")},
                     **placement_kwargs)
 
             if self.chart_canvas.axes2 is not None:

--- a/pandaplot/gui/components/tabs/chart/chart_editor.py
+++ b/pandaplot/gui/components/tabs/chart/chart_editor.py
@@ -1049,30 +1049,43 @@ class ChartEditorWidget(PWidget):
                     config.get("legend_custom_y", 0.5),
                     config.get("legend_custom_anchor", "center left"),
                 )
-                self.chart_canvas.axes.legend(
+                legend = self.chart_canvas.axes.legend(
                     handles, labels,
-                    fontsize=config.get("legend_font_size", 10),
                     facecolor=config.get("legend_bg_color", "#ffffff"),
                     frameon=config.get("legend_show_frame", True),
                     ncol=config.get("legend_columns", 1),
                     framealpha=config.get("legend_bg_alpha", 1.0),
-                    prop={"family": config.get("legend_font_family", "DejaVu Sans")},
+                    # `fontsize=` is silently ignored by Matplotlib whenever
+                    # `prop=` is also passed -- the size must be merged into
+                    # `prop` itself, or the legend text falls back to
+                    # rcParams["legend.fontsize"] regardless of what's
+                    # configured here.
+                    prop={
+                        "family": config.get("legend_font_family", "DejaVu Sans"),
+                        "size": config.get("legend_font_size", 10),
+                    },
                     **placement_kwargs)
+            else:
+                legend = None
 
-            if self.chart_canvas.axes2 is not None:
-                # Reserve room for the secondary axis label/ticks so they
-                # aren't clipped at the right edge of the figure.
-                self.chart_canvas.fig.tight_layout(
-                    pad=config.get("chart_padding", 2.0),
-                    w_pad=config.get("chart_padding_w", 2.0),
-                    h_pad=config.get("chart_padding_h", 2.0),
-                    rect=(0, 0, 1, config.get("top_margin", 1.0)),
-                )
+            tight_layout_kwargs = dict(
+                pad=config.get("chart_padding", 2.0),
+                w_pad=config.get("chart_padding_w", 2.0),
+                h_pad=config.get("chart_padding_h", 2.0),
+                rect=(0, 0, 1, config.get("top_margin", 1.0)),
+            )
+            # Reserve room for the secondary axis label/ticks so they aren't
+            # clipped at the right edge of the figure.
+            self.chart_canvas.fig.tight_layout(**tight_layout_kwargs)
 
-            if self.chart_canvas.axes2 is not None:
-                # Reserve room for the secondary axis label/ticks so they
-                # aren't clipped at the right edge of the figure.
-                self.chart_canvas.fig.tight_layout()
+            if legend is not None and placement_kwargs.get("bbox_to_anchor") is not None:
+                # The legend was placed outside the axes (Outside Right/Top/
+                # Bottom or Custom -- see resolve_legend_placement). The
+                # tight_layout() call above ran before Matplotlib had a
+                # chance to account for this out-of-axes legend's extent in
+                # its first pass, so re-run it now that the legend exists;
+                # otherwise the legend gets clipped by the figure boundary.
+                self.chart_canvas.fig.tight_layout(**tight_layout_kwargs)
 
             # Store original limits for zoom reset functionality
             self.chart_canvas.store_original_limits()

--- a/pandaplot/gui/components/tabs/chart/chart_editor.py
+++ b/pandaplot/gui/components/tabs/chart/chart_editor.py
@@ -176,6 +176,21 @@ def apply_axis_ticks(
     )
 
 
+def apply_tick_label_font(axis, font_size, font_family, bold=False, italic=False):
+    """Set font size/family/weight/style on every major and minor tick-value
+    label of a matplotlib Axis. `Axis.set_tick_params` (used by
+    `apply_axis_ticks` for color/direction) has no font-family/weight/style
+    knobs of its own, so those three must be set directly on each tick
+    label's Text artist instead."""
+    fontweight = "bold" if bold else "normal"
+    fontstyle = "italic" if italic else "normal"
+    for label in axis.get_ticklabels() + axis.get_ticklabels(minor=True):
+        label.set_fontsize(font_size)
+        label.set_fontfamily(font_family)
+        label.set_fontweight(fontweight)
+        label.set_fontstyle(fontstyle)
+
+
 def resolve_axis_color(prefix, own_color, match_enabled, x_color):
     """Resolve the effective color for a Y/Y2 axis element (label, tick
     marks, tick values, or spine): X's color when this axis is matching X
@@ -828,8 +843,18 @@ class ChartEditorWidget(PWidget):
             y_match_label = config.get("y_match_x_label_color", True)
             y_label_color = resolve_axis_color(
                 "y", config.get("y_label_color", "#000000"), y_match_label, x_label_color)
-            self.chart_canvas.axes.set_xlabel(config.get("x_label", ""), color=x_label_color)
-            self.chart_canvas.axes.set_ylabel(config.get("y_label", ""), color=y_label_color)
+            self.chart_canvas.axes.set_xlabel(
+                config.get("x_label", ""), color=x_label_color,
+                fontfamily=config.get("x_font_family", "DejaVu Sans"),
+                fontweight="bold" if config.get("x_title_bold", False) else "normal",
+                fontstyle="italic" if config.get("x_title_italic", False) else "normal",
+            )
+            self.chart_canvas.axes.set_ylabel(
+                config.get("y_label", ""), color=y_label_color,
+                fontfamily=config.get("y_font_family", "DejaVu Sans"),
+                fontweight="bold" if config.get("y_title_bold", False) else "normal",
+                fontstyle="italic" if config.get("y_title_italic", False) else "normal",
+            )
             x_scale = config.get("x_scale", "linear")
             y_scale = config.get("y_scale", "linear")
             self.chart_canvas.axes.set_xscale(x_scale, **resolve_scale_kwargs(x_scale, config.get("x_log_base", 10.0)))
@@ -847,7 +872,12 @@ class ChartEditorWidget(PWidget):
                 y2_match_label = config.get("y2_match_x_label_color", True)
                 y2_label_color = resolve_axis_color(
                     "y2", config.get("y2_label_color", "#000000"), y2_match_label, x_label_color)
-                self.chart_canvas.axes2.set_ylabel(config.get("y2_label", ""), color=y2_label_color)
+                self.chart_canvas.axes2.set_ylabel(
+                    config.get("y2_label", ""), color=y2_label_color,
+                    fontfamily=config.get("y2_font_family", "DejaVu Sans"),
+                    fontweight="bold" if config.get("y2_title_bold", False) else "normal",
+                    fontstyle="italic" if config.get("y2_title_italic", False) else "normal",
+                )
                 y2_scale = config.get("y2_scale", "linear")
                 self.chart_canvas.axes2.set_yscale(
                     y2_scale, **resolve_scale_kwargs(y2_scale, config.get("y2_log_base", 10.0)))
@@ -884,6 +914,14 @@ class ChartEditorWidget(PWidget):
                         config.get("y2_match_x_colors", True),
                         config.get("x_tick_label_color", "#000000")))
 
+                apply_tick_label_font(
+                    self.chart_canvas.axes2.yaxis,
+                    config.get("y2_tick_label_font_size", 10),
+                    config.get("y2_tick_label_font_family", "DejaVu Sans"),
+                    bold=config.get("y2_tick_label_bold", False),
+                    italic=config.get("y2_tick_label_italic", False),
+                )
+
                 if config.get("show_grid_y2", True):
                     self.chart_canvas.axes2.grid(True, axis="y", alpha=config.get("grid_alpha", 0.3))
                 else:
@@ -910,6 +948,13 @@ class ChartEditorWidget(PWidget):
                 major_color=config.get("x_major_tick_color", "#000000"),
                 minor_color=config.get("x_minor_tick_color", "#000000"),
                 labelcolor=config.get("x_tick_label_color", "#000000"))
+            apply_tick_label_font(
+                self.chart_canvas.axes.xaxis,
+                config.get("x_tick_label_font_size", 10),
+                config.get("x_tick_label_font_family", "DejaVu Sans"),
+                bold=config.get("x_tick_label_bold", False),
+                italic=config.get("x_tick_label_italic", False),
+            )
             apply_axis_ticks(
                 self.chart_canvas.axes.yaxis,
                 config.get("y_tick_mode", "auto"), config.get("y_tick_count", 5),
@@ -930,6 +975,13 @@ class ChartEditorWidget(PWidget):
                     "y", config.get("y_tick_label_color", "#000000"),
                     config.get("y_match_x_colors", True),
                     config.get("x_tick_label_color", "#000000")))
+            apply_tick_label_font(
+                self.chart_canvas.axes.yaxis,
+                config.get("y_tick_label_font_size", 10),
+                config.get("y_tick_label_font_family", "DejaVu Sans"),
+                bold=config.get("y_tick_label_bold", False),
+                italic=config.get("y_tick_label_italic", False),
+            )
 
             apply_spine_colors(
                 self.chart_canvas.axes, self.chart_canvas.axes2,

--- a/pandaplot/gui/components/tabs/chart/chart_editor.py
+++ b/pandaplot/gui/components/tabs/chart/chart_editor.py
@@ -300,13 +300,19 @@ def resolve_series_data(project, series, chart_type=None) -> SeriesData:
     return SeriesData(x_data, df[y_column], x_err, y_err, x_err_minus, y_err_minus, None)
 
 
-def compute_axis_data_range(project, data_series, prefix: str) -> Optional[tuple[float, float]]:
+def compute_axis_data_range(project, data_series, prefix: str, positive_only: bool = False) -> Optional[tuple[float, float]]:
     """Compute (min, max) across every series plotted against the given
     axis (`prefix` in "x", "y", "y2"). All series contribute to "x"
     regardless of which y-axis they use; "y"/"y2" are filtered by
     `series.y_axis`. Returns None if no series have resolvable data for
     this axis (no series yet, or every reference is broken) -- callers
-    fall back to a fixed default range in that case."""
+    fall back to a fixed default range in that case.
+
+    `positive_only` should be True when the axis is Log-scaled: matplotlib's
+    own autoscale ignores non-positive data points when computing log-scale
+    view limits (a <= 0 limit is invalid on a log axis and gets silently
+    rejected), so we match that behavior here rather than letting zero/
+    negative values leak into the Range card or into set_xlim/set_ylim."""
     from pandaplot.models.project.items.chart import YAxis
 
     ranges: list[tuple[float, float]] = []
@@ -323,6 +329,8 @@ def compute_axis_data_range(project, data_series, prefix: str) -> Optional[tuple
             continue
         values = np.asarray(arr, dtype=float)
         values = values[np.isfinite(values)]
+        if positive_only:
+            values = values[values > 0]
         if values.size:
             ranges.append((float(values.min()), float(values.max())))
 

--- a/pandaplot/gui/components/tabs/chart/chart_editor.py
+++ b/pandaplot/gui/components/tabs/chart/chart_editor.py
@@ -267,6 +267,40 @@ def resolve_legend_placement(position: str, custom_x: float, custom_y: float, cu
     return {"loc": position}
 
 
+def build_legend(
+    axes, handles, labels,
+    font_family: str, font_size,
+    bg_color: str, show_frame: bool, columns: int, bg_alpha: float,
+    placement_kwargs: dict,
+):
+    """Add a legend to `axes`, merging `font_size` into `prop` alongside
+    `font_family`. Matplotlib silently ignores a `fontsize=` kwarg whenever
+    `prop=` is also passed -- the legend text falls back to
+    rcParams["legend.fontsize"] regardless of what's configured, unless the
+    size is merged into `prop` itself, as done here."""
+    return axes.legend(
+        handles, labels,
+        facecolor=bg_color,
+        frameon=show_frame,
+        ncol=columns,
+        framealpha=bg_alpha,
+        prop={"family": font_family, "size": font_size},
+        **placement_kwargs,
+    )
+
+
+def apply_layout_with_legend(fig, tight_layout_kwargs: dict, legend_placed_outside: bool) -> None:
+    """Run Figure.tight_layout(), re-running it once more when the legend was
+    placed outside the axes (`bbox_to_anchor` set -- Outside Right/Top/Bottom
+    or Custom, see resolve_legend_placement). The first tight_layout() pass
+    runs before Matplotlib can account for an out-of-axes legend's extent,
+    so without the second pass such a legend gets clipped by the figure
+    boundary."""
+    fig.tight_layout(**tight_layout_kwargs)
+    if legend_placed_outside:
+        fig.tight_layout(**tight_layout_kwargs)
+
+
 def _resolve_error_column(df, column_name):
     """Best-effort lookup of an optional error column.
 
@@ -1049,24 +1083,19 @@ class ChartEditorWidget(PWidget):
                     config.get("legend_custom_y", 0.5),
                     config.get("legend_custom_anchor", "center left"),
                 )
-                legend = self.chart_canvas.axes.legend(
-                    handles, labels,
-                    facecolor=config.get("legend_bg_color", "#ffffff"),
-                    frameon=config.get("legend_show_frame", True),
-                    ncol=config.get("legend_columns", 1),
-                    framealpha=config.get("legend_bg_alpha", 1.0),
-                    # `fontsize=` is silently ignored by Matplotlib whenever
-                    # `prop=` is also passed -- the size must be merged into
-                    # `prop` itself, or the legend text falls back to
-                    # rcParams["legend.fontsize"] regardless of what's
-                    # configured here.
-                    prop={
-                        "family": config.get("legend_font_family", "DejaVu Sans"),
-                        "size": config.get("legend_font_size", 10),
-                    },
-                    **placement_kwargs)
+                legend = build_legend(
+                    self.chart_canvas.axes, handles, labels,
+                    config.get("legend_font_family", "DejaVu Sans"),
+                    config.get("legend_font_size", 10),
+                    config.get("legend_bg_color", "#ffffff"),
+                    config.get("legend_show_frame", True),
+                    config.get("legend_columns", 1),
+                    config.get("legend_bg_alpha", 1.0),
+                    placement_kwargs,
+                )
             else:
                 legend = None
+                placement_kwargs = {}
 
             tight_layout_kwargs = dict(
                 pad=config.get("chart_padding", 2.0),
@@ -1076,16 +1105,10 @@ class ChartEditorWidget(PWidget):
             )
             # Reserve room for the secondary axis label/ticks so they aren't
             # clipped at the right edge of the figure.
-            self.chart_canvas.fig.tight_layout(**tight_layout_kwargs)
-
-            if legend is not None and placement_kwargs.get("bbox_to_anchor") is not None:
-                # The legend was placed outside the axes (Outside Right/Top/
-                # Bottom or Custom -- see resolve_legend_placement). The
-                # tight_layout() call above ran before Matplotlib had a
-                # chance to account for this out-of-axes legend's extent in
-                # its first pass, so re-run it now that the legend exists;
-                # otherwise the legend gets clipped by the figure boundary.
-                self.chart_canvas.fig.tight_layout(**tight_layout_kwargs)
+            apply_layout_with_legend(
+                self.chart_canvas.fig, tight_layout_kwargs,
+                legend is not None and placement_kwargs.get("bbox_to_anchor") is not None,
+            )
 
             # Store original limits for zoom reset functionality
             self.chart_canvas.store_original_limits()

--- a/pandaplot/gui/components/tabs/chart/chart_editor.py
+++ b/pandaplot/gui/components/tabs/chart/chart_editor.py
@@ -1,6 +1,7 @@
 from dataclasses import dataclass
 from typing import Any, Optional, override
 
+import numpy as np
 from matplotlib.ticker import (
     AutoLocator,
     AutoMinorLocator,
@@ -297,6 +298,37 @@ def resolve_series_data(project, series, chart_type=None) -> SeriesData:
     x_err_minus = _resolve_error_column(df, resolve_series_column(dataset, series.x_error_minus_column_id, series.x_error_minus_column))
     y_err_minus = _resolve_error_column(df, resolve_series_column(dataset, series.y_error_minus_column_id, series.y_error_minus_column))
     return SeriesData(x_data, df[y_column], x_err, y_err, x_err_minus, y_err_minus, None)
+
+
+def compute_axis_data_range(project, data_series, prefix: str) -> Optional[tuple[float, float]]:
+    """Compute (min, max) across every series plotted against the given
+    axis (`prefix` in "x", "y", "y2"). All series contribute to "x"
+    regardless of which y-axis they use; "y"/"y2" are filtered by
+    `series.y_axis`. Returns None if no series have resolvable data for
+    this axis (no series yet, or every reference is broken) -- callers
+    fall back to a fixed default range in that case."""
+    from pandaplot.models.project.items.chart import YAxis
+
+    ranges: list[tuple[float, float]] = []
+    for series in data_series:
+        if prefix in ("y", "y2"):
+            wants_secondary = prefix == "y2"
+            if (series.y_axis == YAxis.SECONDARY) != wants_secondary:
+                continue
+        data = resolve_series_data(project, series)
+        if data.error:
+            continue
+        arr = data.x_data if prefix == "x" else data.y_data
+        if arr is None:
+            continue
+        values = np.asarray(arr, dtype=float)
+        values = values[np.isfinite(values)]
+        if values.size:
+            ranges.append((float(values.min()), float(values.max())))
+
+    if not ranges:
+        return None
+    return (min(r[0] for r in ranges), max(r[1] for r in ranges))
 
 
 class ChartEditorWidget(PWidget):

--- a/pandaplot/gui/components/tabs/chart/chart_editor.py
+++ b/pandaplot/gui/components/tabs/chart/chart_editor.py
@@ -190,6 +190,15 @@ def resolve_axis_color(prefix, own_color, match_enabled, x_color):
     return x_color if match_enabled else own_color
 
 
+def resolve_scale_kwargs(scale: str, log_base: float) -> dict:
+    """Build the extra kwargs for Axes.set_xscale/set_yscale: a log axis
+    needs an explicit `base` (matplotlib requires base > 0 and base != 1,
+    which also covers custom bases between 0 and 1); a linear axis's scale
+    class doesn't accept a `base` kwarg at all, so it must be omitted
+    entirely rather than passed as None/default."""
+    return {"base": log_base} if scale == "log" else {}
+
+
 def apply_spine_colors(axes, axes2, x_color, y_color, y2_color):
     """Color the axis box lines ('spines'). Bottom/top belong to x, left
     belongs to y. Right belongs to y2 when a secondary y axis is active,
@@ -771,8 +780,10 @@ class ChartEditorWidget(PWidget):
                 "y", config.get("y_label_color", "#000000"), y_match_label, x_label_color)
             self.chart_canvas.axes.set_xlabel(config.get("x_label", ""), color=x_label_color)
             self.chart_canvas.axes.set_ylabel(config.get("y_label", ""), color=y_label_color)
-            self.chart_canvas.axes.set_xscale(config.get("x_scale", "linear"))
-            self.chart_canvas.axes.set_yscale(config.get("y_scale", "linear"))
+            x_scale = config.get("x_scale", "linear")
+            y_scale = config.get("y_scale", "linear")
+            self.chart_canvas.axes.set_xscale(x_scale, **resolve_scale_kwargs(x_scale, config.get("x_log_base", 10.0)))
+            self.chart_canvas.axes.set_yscale(y_scale, **resolve_scale_kwargs(y_scale, config.get("y_log_base", 10.0)))
             self.chart_canvas.axes.xaxis.label.set_size(config.get("x_font_size", 12))
             self.chart_canvas.axes.yaxis.label.set_size(config.get("y_font_size", 12))
             if config.get("y_side", "left") == "right":
@@ -787,7 +798,9 @@ class ChartEditorWidget(PWidget):
                 y2_label_color = resolve_axis_color(
                     "y2", config.get("y2_label_color", "#000000"), y2_match_label, x_label_color)
                 self.chart_canvas.axes2.set_ylabel(config.get("y2_label", ""), color=y2_label_color)
-                self.chart_canvas.axes2.set_yscale(config.get("y2_scale", "linear"))
+                y2_scale = config.get("y2_scale", "linear")
+                self.chart_canvas.axes2.set_yscale(
+                    y2_scale, **resolve_scale_kwargs(y2_scale, config.get("y2_log_base", 10.0)))
                 self.chart_canvas.axes2.yaxis.label.set_size(config.get("y2_font_size", 12))
                 if config.get("y2_side", "right") == "left":
                     self.chart_canvas.axes2.yaxis.tick_left()

--- a/pandaplot/gui/components/tabs/chart/chart_editor.py
+++ b/pandaplot/gui/components/tabs/chart/chart_editor.py
@@ -195,8 +195,18 @@ def resolve_scale_kwargs(scale: str, log_base: float) -> dict:
     needs an explicit `base` (matplotlib requires base > 0 and base != 1,
     which also covers custom bases between 0 and 1); a linear axis's scale
     class doesn't accept a `base` kwarg at all, so it must be omitted
-    entirely rather than passed as None/default."""
-    return {"base": log_base} if scale == "log" else {}
+    entirely rather than passed as None/default.
+
+    Validated defensively here (not just in the GUI's write path) because
+    `log_base` may come from a hand-edited or corrupted project file: an
+    invalid value (<= 0 or exactly 1.0) would otherwise reach
+    Axes.set_xscale/set_yscale unfiltered and raise an unhandled
+    ValueError, crashing rendering. Falls back to base 10 instead."""
+    if scale != "log":
+        return {}
+    if log_base <= 0 or log_base == 1.0:
+        log_base = 10.0
+    return {"base": log_base}
 
 
 def apply_spine_colors(axes, axes2, x_color, y_color, y2_color):

--- a/tests/gui/test_axes_tab.py
+++ b/tests/gui/test_axes_tab.py
@@ -2,11 +2,11 @@
 
 1. `_read_axis_config` used to set match-toggle checked state AFTER
    loading swatch colors from `chart.config`. `ToggleSwitch.setChecked`
-   emits `toggled` unconditionally, and the toggled handlers
-   (`_on_match_x_label_toggled`/`_on_match_x_colors_toggled`) pre-fill
-   their swatches from X's *current* color whenever the new state is "not
-   matching" -- silently clobbering a saved custom color the moment a
-   chart with `y_match_x_colors=False` loaded.
+   emits `toggled` unconditionally, and the toggled handler
+   (`_on_match_x_colors_toggled`) pre-fills its swatches from X's
+   *current* color whenever the new state is "not matching" -- silently
+   clobbering a saved custom color the moment a chart with
+   `y_match_x_colors=False` loaded.
 
 2. `_on_copy_axis_settings` had the same ordering bug: it copied the
    source axis's colors into the target BEFORE setting the target's match
@@ -66,14 +66,11 @@ def test_load_preserves_custom_y_colors_when_not_matching_x():
         "x_major_tick_color": "#111111",
         "x_minor_tick_color": "#111111",
         "x_tick_label_color": "#111111",
-        "x_label_color": "#111111",
         "y_match_x_colors": False,
         "y_spine_color": "#abcdef",
         "y_major_tick_color": "#abcdef",
         "y_minor_tick_color": "#abcdef",
         "y_tick_label_color": "#abcdef",
-        "y_match_x_label_color": False,
-        "y_label_color": "#fedcba",
     })
 
     tab = AxesTab(_make_app_context())
@@ -85,8 +82,6 @@ def test_load_preserves_custom_y_colors_when_not_matching_x():
     assert y_form["major_tick_color_row"].currentColor() == "#abcdef"
     assert y_form["minor_tick_color_row"].currentColor() == "#abcdef"
     assert y_form["tick_label_color_row"].currentColor() == "#abcdef"
-    assert y_form["match_x_label_toggle"].isChecked() is False
-    assert y_form["label_color_row"].currentColor() == "#fedcba"
 
 
 def test_copy_axis_settings_copies_source_colors_not_x_colors():
@@ -98,14 +93,11 @@ def test_copy_axis_settings_copies_source_colors_not_x_colors():
         "x_major_tick_color": "#111111",
         "x_minor_tick_color": "#111111",
         "x_tick_label_color": "#111111",
-        "x_label_color": "#111111",
         "y2_match_x_colors": False,
         "y2_spine_color": "#00ff00",
         "y2_major_tick_color": "#00ff00",
         "y2_minor_tick_color": "#00ff00",
         "y2_tick_label_color": "#00ff00",
-        "y2_match_x_label_color": False,
-        "y2_label_color": "#00aa00",
         # Y starts out matching X (default), which is the state being
         # flipped away from during the copy.
     })
@@ -125,8 +117,6 @@ def test_copy_axis_settings_copies_source_colors_not_x_colors():
     assert y_form["major_tick_color_row"].currentColor() == "#00ff00"
     assert y_form["minor_tick_color_row"].currentColor() == "#00ff00"
     assert y_form["tick_label_color_row"].currentColor() == "#00ff00"
-    assert y_form["match_x_label_toggle"].isChecked() is False
-    assert y_form["label_color_row"].currentColor() == "#00aa00"
 
 
 def test_selecting_custom_log_base_reveals_spin_and_round_trips_into_config():

--- a/tests/gui/test_axes_tab.py
+++ b/tests/gui/test_axes_tab.py
@@ -1,17 +1,9 @@
-"""Regression tests for two ordering bugs in AxesTab (axes_tab.py):
+"""Regression tests for AxesTab (axes_tab.py).
 
-1. `_read_axis_config` used to set match-toggle checked state AFTER
-   loading swatch colors from `chart.config`. `ToggleSwitch.setChecked`
-   emits `toggled` unconditionally, and the toggled handler
-   (`_on_match_x_colors_toggled`) pre-fills its swatches from X's
-   *current* color whenever the new state is "not matching" -- silently
-   clobbering a saved custom color the moment a chart with
-   `y_match_x_colors=False` loaded.
-
-2. `_on_copy_axis_settings` had the same ordering bug: it copied the
-   source axis's colors into the target BEFORE setting the target's match
-   toggles, so if the target's toggle changed state, the toggled handler's
-   pre-fill overwrote the just-copied colors with X's instead.
+Note: the ordering-bug regression tests for the Colors card's Match-X
+toggle (spine/major/minor tick colors) moved to
+tests/gui/test_style_tab_axes_colors.py as of Task 6, since that Colors
+card itself moved from AxesTab into StyleTab's "Axes" section.
 """
 import types
 
@@ -54,69 +46,6 @@ def _make_dataset(id_, x, y):
     ds = Dataset(id=id_, name=id_)
     ds.data = pd.DataFrame({"x": x, "y": y})
     return ds
-
-
-def test_load_preserves_custom_y_colors_when_not_matching_x():
-    """Loading a chart where Y opted out of matching X's colors, with its
-    own custom spine/tick colors saved, must NOT have those colors
-    replaced by X's colors just because the chart loaded."""
-    chart = Chart(name="Test Chart")
-    chart.update_config({
-        "x_spine_color": "#111111",
-        "x_major_tick_color": "#111111",
-        "x_minor_tick_color": "#111111",
-        "x_tick_label_color": "#111111",
-        "y_match_x_colors": False,
-        "y_spine_color": "#abcdef",
-        "y_major_tick_color": "#abcdef",
-        "y_minor_tick_color": "#abcdef",
-        "y_tick_label_color": "#abcdef",
-    })
-
-    tab = AxesTab(_make_app_context())
-    tab.load(chart)
-
-    y_form = tab.axes_forms["y"]
-    assert y_form["match_x_colors_toggle"].isChecked() is False
-    assert y_form["spine_color_row"].currentColor() == "#abcdef"
-    assert y_form["major_tick_color_row"].currentColor() == "#abcdef"
-    assert y_form["minor_tick_color_row"].currentColor() == "#abcdef"
-    assert y_form["tick_label_color_row"].currentColor() == "#abcdef"
-
-
-def test_copy_axis_settings_copies_source_colors_not_x_colors():
-    """Copying Y2 (unmatched, with custom colors) into Y must leave Y with
-    Y2's colors -- not X's -- even though copying flips Y's match toggle."""
-    chart = Chart(name="Test Chart")
-    chart.update_config({
-        "x_spine_color": "#111111",
-        "x_major_tick_color": "#111111",
-        "x_minor_tick_color": "#111111",
-        "x_tick_label_color": "#111111",
-        "y2_match_x_colors": False,
-        "y2_spine_color": "#00ff00",
-        "y2_major_tick_color": "#00ff00",
-        "y2_minor_tick_color": "#00ff00",
-        "y2_tick_label_color": "#00ff00",
-        # Y starts out matching X (default), which is the state being
-        # flipped away from during the copy.
-    })
-    chart.add_data_series(dataset_id="ds1", x_column="x", y_column="y", y_axis="secondary")
-
-    tab = AxesTab(_make_app_context())
-    tab.load(chart)
-
-    # Sanity check: Y starts out matching X, as loaded.
-    y_form = tab.axes_forms["y"]
-    assert y_form["match_x_colors_toggle"].isChecked() is True
-
-    tab._on_copy_axis_settings("y2")
-
-    assert y_form["match_x_colors_toggle"].isChecked() is False
-    assert y_form["spine_color_row"].currentColor() == "#00ff00"
-    assert y_form["major_tick_color_row"].currentColor() == "#00ff00"
-    assert y_form["minor_tick_color_row"].currentColor() == "#00ff00"
-    assert y_form["tick_label_color_row"].currentColor() == "#00ff00"
 
 
 def test_selecting_custom_log_base_reveals_spin_and_round_trips_into_config():

--- a/tests/gui/test_axes_tab.py
+++ b/tests/gui/test_axes_tab.py
@@ -11,6 +11,7 @@ import pytest
 from PySide6.QtWidgets import QApplication
 
 from pandaplot.gui.components.sidebar.chart.tabs.axes_tab import AxesTab
+from pandaplot.models.chart.chart_configuration import ScaleType
 from pandaplot.models.project.items.chart import Chart, DataSeries
 from pandaplot.models.project.items.dataset import Dataset
 
@@ -220,3 +221,58 @@ def test_toggling_auto_to_manual_recomputes_fresh_from_data():
     assert y_form["max_spin"].value() == 300.0
     assert y_form["min_spin"].isEnabled() is True
     assert y_form["max_spin"].isEnabled() is True
+
+
+def test_range_spin_boxes_do_not_round_away_small_magnitude_data():
+    """The Range card's min/max spin boxes must not silently round a
+    small-magnitude computed data range to 0.00/0.01 (Qt's default of 2
+    decimal places) -- Task 4 made these boxes display machine-computed
+    ranges, and a rounded-to-zero min on a subsequent Auto->Manual toggle
+    would write a degenerate (or, on a log axis, invalid) limit into
+    config."""
+    ds = _make_dataset("ds1", x=[1, 2, 3], y=[0.001, 0.005, 0.009])
+    project = _FakeProject([ds])
+    chart = Chart(name="Test Chart")
+    chart.update_config({"y_auto_limits": True})
+    chart.add_data_series(dataset_id="ds1", x_column="x", y_column="y")
+
+    tab = AxesTab(_make_app_context(project))
+    tab.load(chart)
+
+    y_form = tab.axes_forms["y"]
+    assert y_form["min_spin"].value() == pytest.approx(0.001)
+    assert y_form["max_spin"].value() == pytest.approx(0.009)
+    assert y_form["min_spin"].decimals() >= 6
+    assert y_form["max_spin"].decimals() >= 6
+
+
+def test_switching_linear_to_log_refreshes_auto_range_to_positive_only():
+    """Switching an Auto axis's Scale from Linear to Log must immediately
+    refresh the displayed range to the positive-only-filtered range (Task
+    4's `positive_only` filtering only takes effect through
+    `_refresh_range_display`) -- not leave the pre-switch linear range
+    (which may include a non-positive min invalid for a log axis) on
+    display."""
+    ds = _make_dataset("ds1", x=[1, 2, 3], y=[-5, 10, 20])
+    project = _FakeProject([ds])
+    chart = Chart(name="Test Chart")
+    chart.update_config({"y_auto_limits": True, "y_scale": "linear"})
+    chart.add_data_series(dataset_id="ds1", x_column="x", y_column="y")
+
+    tab = AxesTab(_make_app_context(project))
+    tab.load(chart)
+
+    y_form = tab.axes_forms["y"]
+    assert y_form["min_spin"].value() == -5.0
+    assert y_form["max_spin"].value() == 20.0
+
+    # SegmentedControl.setCurrentValue() is a silent programmatic setter (no
+    # currentValueChanged emitted) -- only a real button click fires the
+    # signal that drives _on_scale_changed, so click the "Log" segment
+    # rather than calling setCurrentValue() directly.
+    log_index = y_form["scale_control"]._values.index(ScaleType.LOG)
+    y_form["scale_control"]._buttons[log_index].click()
+
+    assert y_form["scale_control"].currentValue() == ScaleType.LOG
+    assert y_form["min_spin"].value() == 10.0
+    assert y_form["max_spin"].value() == 20.0

--- a/tests/gui/test_axes_tab.py
+++ b/tests/gui/test_axes_tab.py
@@ -258,6 +258,25 @@ def test_load_auto_axis_shows_recomputed_data_range_disabled():
     assert y_form["max_spin"].isEnabled() is False
 
 
+def test_log_scale_axis_range_display_excludes_non_positive_values():
+    """A Log-scaled axis must show Min/Max computed from only the positive
+    subset of the data -- matplotlib's log-scale autoscale ignores
+    non-positive points entirely, and a raw min <= 0 would later be
+    silently rejected by set_ylim() on a log axis."""
+    ds = _make_dataset("ds1", x=[1, 2, 3], y=[-5, 10, 20])
+    project = _FakeProject([ds])
+    chart = Chart(name="Test Chart")
+    chart.update_config({"y_auto_limits": True, "y_scale": "log"})
+    chart.add_data_series(dataset_id="ds1", x_column="x", y_column="y")
+
+    tab = AxesTab(_make_app_context(project))
+    tab.load(chart)
+
+    y_form = tab.axes_forms["y"]
+    assert y_form["min_spin"].value() == 10.0
+    assert y_form["max_spin"].value() == 20.0
+
+
 def test_toggling_auto_to_manual_recomputes_fresh_from_data():
     """Regression check: an explicit Auto->Manual toggle is the one case
     that SHOULD still recompute-and-overwrite -- it must ignore whatever

--- a/tests/gui/test_axes_tab.py
+++ b/tests/gui/test_axes_tab.py
@@ -13,6 +13,8 @@
    toggles, so if the target's toggle changed state, the toggled handler's
    pre-fill overwrote the just-copied colors with X's instead.
 """
+import types
+
 import pytest
 from PySide6.QtWidgets import QApplication
 
@@ -24,6 +26,15 @@ from pandaplot.models.project.items.chart import Chart
 def qapp():
     app = QApplication.instance() or QApplication([])
     yield app
+
+
+def _make_app_context():
+    """Minimal stand-in exposing the one attribute AxesTab reads:
+    `app_context.app_state.current_project` (consulted by
+    `_refresh_range_display`). None here means `compute_axis_data_range`
+    can't resolve any series and falls back to (0.0, 1.0), which is fine
+    since these tests don't assert on the Range card's min/max values."""
+    return types.SimpleNamespace(app_state=types.SimpleNamespace(current_project=None))
 
 
 def test_load_preserves_custom_y_colors_when_not_matching_x():
@@ -46,7 +57,7 @@ def test_load_preserves_custom_y_colors_when_not_matching_x():
         "y_label_color": "#fedcba",
     })
 
-    tab = AxesTab()
+    tab = AxesTab(_make_app_context())
     tab.load(chart)
 
     y_form = tab.axes_forms["y"]
@@ -81,7 +92,7 @@ def test_copy_axis_settings_copies_source_colors_not_x_colors():
     })
     chart.add_data_series(dataset_id="ds1", x_column="x", y_column="y", y_axis="secondary")
 
-    tab = AxesTab()
+    tab = AxesTab(_make_app_context())
     tab.load(chart)
 
     # Sanity check: Y starts out matching X, as loaded.
@@ -107,7 +118,7 @@ def test_selecting_custom_log_base_reveals_spin_and_round_trips_into_config():
     chart = Chart(name="Test Chart")
     chart.update_config({"y_scale": "log"})
 
-    tab = AxesTab()
+    tab = AxesTab(_make_app_context())
     tab.load(chart)
 
     y_form = tab.axes_forms["y"]
@@ -128,7 +139,7 @@ def test_log_base_of_one_falls_back_to_ten():
     chart = Chart(name="Test Chart")
     chart.update_config({"y_scale": "log"})
 
-    tab = AxesTab()
+    tab = AxesTab(_make_app_context())
     tab.load(chart)
 
     y_form = tab.axes_forms["y"]
@@ -148,7 +159,7 @@ def test_copy_axis_settings_copies_log_base_from_source_y_to_target_y2():
     chart.update_config({"y_scale": "log", "y_log_base": 2.0})
     chart.add_data_series(dataset_id="ds1", x_column="x", y_column="y", y_axis="secondary")
 
-    tab = AxesTab()
+    tab = AxesTab(_make_app_context())
     tab.load(chart)
 
     y2_form = tab.axes_forms["y2"]
@@ -168,7 +179,7 @@ def test_load_selects_custom_for_non_preset_log_base_and_populates_spin():
     chart = Chart(name="Test Chart")
     chart.update_config({"y_scale": "log", "y_log_base": 3.5})
 
-    tab = AxesTab()
+    tab = AxesTab(_make_app_context())
     tab.load(chart)
 
     y_form = tab.axes_forms["y"]

--- a/tests/gui/test_axes_tab.py
+++ b/tests/gui/test_axes_tab.py
@@ -97,3 +97,82 @@ def test_copy_axis_settings_copies_source_colors_not_x_colors():
     assert y_form["tick_label_color_row"].currentColor() == "#00ff00"
     assert y_form["match_x_label_toggle"].isChecked() is False
     assert y_form["label_color_row"].currentColor() == "#00aa00"
+
+
+def test_selecting_custom_log_base_reveals_spin_and_round_trips_into_config():
+    """Selecting "Custom..." on the log-base combo reveals the custom spin
+    box, and the spin box's value round-trips into
+    chart.config[f"{prefix}_log_base"] via the real _on_field_changed ->
+    _write_axis_config -> _resolve_log_base path."""
+    chart = Chart(name="Test Chart")
+    chart.update_config({"y_scale": "log"})
+
+    tab = AxesTab()
+    tab.load(chart)
+
+    y_form = tab.axes_forms["y"]
+    custom_index = y_form["log_base_combo"].findData("custom")
+    y_form["log_base_combo"].setCurrentIndex(custom_index)
+
+    assert y_form["log_base_custom_spin"].isHidden() is False
+
+    y_form["log_base_custom_spin"].setValue(4.2)
+
+    assert chart.config["y_log_base"] == 4.2
+
+
+def test_log_base_of_one_falls_back_to_ten():
+    """A log base of exactly 1.0 is invalid for matplotlib's LogScale;
+    _resolve_log_base (invoked via the custom spin box's valueChanged ->
+    _on_field_changed -> _write_axis_config path) must fall back to 10.0."""
+    chart = Chart(name="Test Chart")
+    chart.update_config({"y_scale": "log"})
+
+    tab = AxesTab()
+    tab.load(chart)
+
+    y_form = tab.axes_forms["y"]
+    custom_index = y_form["log_base_combo"].findData("custom")
+    y_form["log_base_combo"].setCurrentIndex(custom_index)
+    y_form["log_base_custom_spin"].setValue(1.0)
+
+    assert chart.config["y_log_base"] == 10.0
+
+
+def test_copy_axis_settings_copies_log_base_from_source_y_to_target_y2():
+    """_on_copy_axis_settings("y") must copy Y's log-base combo selection
+    into Y2, and the copy must be observable in chart.config (not just the
+    widget state), since _on_field_changed writes all three axes' config
+    at the end of the copy."""
+    chart = Chart(name="Test Chart")
+    chart.update_config({"y_scale": "log", "y_log_base": 2.0})
+    chart.add_data_series(dataset_id="ds1", x_column="x", y_column="y", y_axis="secondary")
+
+    tab = AxesTab()
+    tab.load(chart)
+
+    y2_form = tab.axes_forms["y2"]
+    # Sanity check: Y2 starts out at the default base (10.0), distinct from Y's 2.0.
+    assert y2_form["log_base_combo"].currentData() == 10.0
+
+    tab._on_copy_axis_settings("y")
+
+    assert y2_form["log_base_combo"].currentData() == 2.0
+    assert chart.config["y2_log_base"] == 2.0
+
+
+def test_load_selects_custom_for_non_preset_log_base_and_populates_spin():
+    """Loading a chart whose config has a non-preset log base (3.5) must
+    select "Custom..." in the combo and populate the custom spin box with
+    3.5 -- the round-trip of _read_axis_config for a saved custom base."""
+    chart = Chart(name="Test Chart")
+    chart.update_config({"y_scale": "log", "y_log_base": 3.5})
+
+    tab = AxesTab()
+    tab.load(chart)
+
+    y_form = tab.axes_forms["y"]
+    assert y_form["log_base_combo"].currentData() == "custom"
+    assert y_form["log_base_custom_spin"].value() == 3.5
+    assert y_form["log_base_custom_spin"].isHidden() is False
+    assert y_form["log_base_row"].isHidden() is False

--- a/tests/gui/test_axes_tab.py
+++ b/tests/gui/test_axes_tab.py
@@ -19,7 +19,8 @@ import pytest
 from PySide6.QtWidgets import QApplication
 
 from pandaplot.gui.components.sidebar.chart.tabs.axes_tab import AxesTab
-from pandaplot.models.project.items.chart import Chart
+from pandaplot.models.project.items.chart import Chart, DataSeries
+from pandaplot.models.project.items.dataset import Dataset
 
 
 @pytest.fixture(scope="module", autouse=True)
@@ -28,13 +29,31 @@ def qapp():
     yield app
 
 
-def _make_app_context():
+def _make_app_context(project=None):
     """Minimal stand-in exposing the one attribute AxesTab reads:
     `app_context.app_state.current_project` (consulted by
     `_refresh_range_display`). None here means `compute_axis_data_range`
     can't resolve any series and falls back to (0.0, 1.0), which is fine
     since these tests don't assert on the Range card's min/max values."""
-    return types.SimpleNamespace(app_state=types.SimpleNamespace(current_project=None))
+    return types.SimpleNamespace(app_state=types.SimpleNamespace(current_project=project))
+
+
+class _FakeProject:
+    """Minimal stand-in for a project, exposing only the `find_item` lookup
+    `compute_axis_data_range` -> `resolve_series_data` needs."""
+
+    def __init__(self, datasets):
+        self._datasets = {d.id: d for d in datasets}
+
+    def find_item(self, item_id):
+        return self._datasets.get(item_id)
+
+
+def _make_dataset(id_, x, y):
+    import pandas as pd
+    ds = Dataset(id=id_, name=id_)
+    ds.data = pd.DataFrame({"x": x, "y": y})
+    return ds
 
 
 def test_load_preserves_custom_y_colors_when_not_matching_x():
@@ -187,3 +206,79 @@ def test_load_selects_custom_for_non_preset_log_base_and_populates_spin():
     assert y_form["log_base_custom_spin"].value() == 3.5
     assert y_form["log_base_custom_spin"].isHidden() is False
     assert y_form["log_base_row"].isHidden() is False
+
+
+def test_load_manual_axis_shows_saved_range_not_recomputed_data_range():
+    """A Manual-mode axis's displayed min/max on load must be exactly what
+    was saved in chart.config, even when the chart's series data would
+    compute to a completely different range. Loading/reopening a chart is
+    NOT an Auto->Manual toggle, so it must never recompute-and-overwrite a
+    Manual axis's value (the bug this test guards against: `load()` used to
+    call `_refresh_range_display` unconditionally for every axis, silently
+    clobbering the saved manual range with the live data range)."""
+    ds = _make_dataset("ds1", x=[1, 2, 3], y=[100, 200, 300])
+    project = _FakeProject([ds])
+    chart = Chart(name="Test Chart")
+    chart.update_config({
+        "y_auto_limits": False,
+        "y_min": 5.0,
+        "y_max": 50.0,
+    })
+    chart.add_data_series(dataset_id="ds1", x_column="x", y_column="y")
+
+    tab = AxesTab(_make_app_context(project))
+    tab.load(chart)
+
+    y_form = tab.axes_forms["y"]
+    assert y_form["auto_toggle"].isChecked() is False
+    assert y_form["min_spin"].value() == 5.0
+    assert y_form["max_spin"].value() == 50.0
+    assert y_form["min_spin"].isEnabled() is True
+    assert y_form["max_spin"].isEnabled() is True
+
+
+def test_load_auto_axis_shows_recomputed_data_range_disabled():
+    """Regression check: an Auto-mode axis must still show the freshly
+    recomputed data range on load, disabled -- the Auto path is unaffected
+    by the Manual-mode fix above."""
+    ds = _make_dataset("ds1", x=[1, 2, 3], y=[100, 200, 300])
+    project = _FakeProject([ds])
+    chart = Chart(name="Test Chart")
+    chart.update_config({"y_auto_limits": True})
+    chart.add_data_series(dataset_id="ds1", x_column="x", y_column="y")
+
+    tab = AxesTab(_make_app_context(project))
+    tab.load(chart)
+
+    y_form = tab.axes_forms["y"]
+    assert y_form["auto_toggle"].isChecked() is True
+    assert y_form["min_spin"].value() == 100.0
+    assert y_form["max_spin"].value() == 300.0
+    assert y_form["min_spin"].isEnabled() is False
+    assert y_form["max_spin"].isEnabled() is False
+
+
+def test_toggling_auto_to_manual_recomputes_fresh_from_data():
+    """Regression check: an explicit Auto->Manual toggle is the one case
+    that SHOULD still recompute-and-overwrite -- it must ignore whatever
+    stale value happened to be sitting in the spin boxes and show the
+    current data range instead."""
+    ds = _make_dataset("ds1", x=[1, 2, 3], y=[100, 200, 300])
+    project = _FakeProject([ds])
+    chart = Chart(name="Test Chart")
+    chart.update_config({"y_auto_limits": True})
+    chart.add_data_series(dataset_id="ds1", x_column="x", y_column="y")
+
+    tab = AxesTab(_make_app_context(project))
+    tab.load(chart)
+
+    y_form = tab.axes_forms["y"]
+    assert y_form["min_spin"].value() == 100.0
+    assert y_form["max_spin"].value() == 300.0
+
+    y_form["auto_toggle"].setChecked(False)
+
+    assert y_form["min_spin"].value() == 100.0
+    assert y_form["max_spin"].value() == 300.0
+    assert y_form["min_spin"].isEnabled() is True
+    assert y_form["max_spin"].isEnabled() is True

--- a/tests/gui/test_chart_editor_axis_title_font.py
+++ b/tests/gui/test_chart_editor_axis_title_font.py
@@ -1,0 +1,44 @@
+"""Unit tests for apply_tick_label_font(), the pure helper that sets
+font family/size/weight/style on every major and minor tick-value label of
+a matplotlib Axis (tick_params can't carry font-family/weight/style, so
+these must be set directly on each Text artist)."""
+from matplotlib.figure import Figure
+
+from pandaplot.gui.components.tabs.chart.chart_editor import apply_axis_ticks, apply_tick_label_font
+
+
+def _make_axis():
+    fig = Figure()
+    ax = fig.add_subplot(111)
+    ax.set_xlim(0, 10)
+    return ax.xaxis
+
+
+def test_sets_font_family_size_on_major_tick_labels():
+    axis = _make_axis()
+    apply_axis_ticks(axis, "auto", 5, 1.0, "auto", "")
+    apply_tick_label_font(axis, font_size=14, font_family="Georgia", bold=False, italic=False)
+    labels = [label for label in axis.get_ticklabels() if label.get_text()]
+    assert labels, "expected at least one tick label after autoscale"
+    for label in labels:
+        assert label.get_fontfamily() == ["Georgia"]
+        assert label.get_fontsize() == 14
+
+
+def test_bold_and_italic_are_applied_to_tick_labels():
+    axis = _make_axis()
+    apply_axis_ticks(axis, "auto", 5, 1.0, "auto", "")
+    apply_tick_label_font(axis, font_size=10, font_family="DejaVu Sans", bold=True, italic=True)
+    labels = [label for label in axis.get_ticklabels() if label.get_text()]
+    for label in labels:
+        assert label.get_fontweight() == "bold"
+        assert label.get_fontstyle() == "italic"
+
+
+def test_minor_tick_labels_also_get_the_font():
+    axis = _make_axis()
+    apply_axis_ticks(axis, "auto", 5, 1.0, "auto", "", minor_enabled=True)
+    apply_tick_label_font(axis, font_size=8, font_family="Georgia", bold=False, italic=False)
+    minor_labels = [label for label in axis.get_ticklabels(minor=True) if label.get_text()]
+    for label in minor_labels:
+        assert label.get_fontfamily() == ["Georgia"]

--- a/tests/gui/test_chart_editor_legend_font_size.py
+++ b/tests/gui/test_chart_editor_legend_font_size.py
@@ -1,22 +1,12 @@
-"""Pure-matplotlib regression test for the legend font-size bug in
-ChartEditor.update_chart (mirrors test_chart_editor_background_rendering.py):
+"""Regression test for the legend font-size bug in ChartEditor.update_chart:
 Matplotlib silently ignores a `.legend(fontsize=...)` kwarg whenever `prop=`
 is also passed, so the configured legend font size only takes effect if it's
-merged into the `prop` dict alongside `family`."""
+merged into the `prop` dict alongside `family`. This exercises the real
+`build_legend` helper used by `ChartEditorWidget.update_chart` (extracted so
+it can be tested without a live QApplication/canvas)."""
 from matplotlib.figure import Figure
 
-
-def render_legend_broken(fig, axes, handles, labels, font_size, font_family):
-    """The pre-fix `.legend(...)` call: `fontsize=` and `prop={"family": ...}`
-    passed together."""
-    return axes.legend(handles, labels, fontsize=font_size, prop={"family": font_family})
-
-
-def render_legend_fixed(fig, axes, handles, labels, font_size, font_family):
-    """Mirrors the corrected `.legend(...)` call in ChartEditor.update_chart:
-    the size is merged into `prop` instead of passed as a separate
-    `fontsize=` kwarg."""
-    return axes.legend(handles, labels, prop={"family": font_family, "size": font_size})
+from pandaplot.gui.components.tabs.chart.chart_editor import build_legend
 
 
 def _plot_one_series(fig):
@@ -25,26 +15,36 @@ def _plot_one_series(fig):
     return axes, *axes.get_legend_handles_labels()
 
 
-def test_broken_call_ignores_configured_font_size_when_prop_also_set():
-    """Documents the bug: with both `fontsize=` and `prop=` (without `size`
-    in `prop`), the legend text falls back to rcParams["legend.fontsize"],
-    not the configured size."""
+def test_build_legend_applies_configured_font_size_with_font_family_set():
     fig = Figure()
     axes, handles, labels = _plot_one_series(fig)
-    legend = render_legend_broken(fig, axes, handles, labels, 22, "DejaVu Sans")
-    assert legend.get_texts()[0].get_fontsize() != 22
-
-
-def test_fixed_call_applies_configured_font_size_with_font_family_set():
-    fig = Figure()
-    axes, handles, labels = _plot_one_series(fig)
-    legend = render_legend_fixed(fig, axes, handles, labels, 22, "DejaVu Sans")
+    legend = build_legend(
+        axes, handles, labels,
+        "DejaVu Sans", 22,
+        "#ffffff", True, 1, 1.0,
+        {"loc": "upper right"},
+    )
     assert legend.get_texts()[0].get_fontsize() == 22
     assert legend.get_texts()[0].get_fontfamily() == ["DejaVu Sans"]
 
 
-def test_fixed_call_applies_default_font_size_of_ten():
+def test_build_legend_applies_default_font_size_of_ten():
     fig = Figure()
     axes, handles, labels = _plot_one_series(fig)
-    legend = render_legend_fixed(fig, axes, handles, labels, 10, "DejaVu Sans")
+    legend = build_legend(
+        axes, handles, labels,
+        "DejaVu Sans", 10,
+        "#ffffff", True, 1, 1.0,
+        {"loc": "upper right"},
+    )
     assert legend.get_texts()[0].get_fontsize() == 10
+
+
+def test_passing_fontsize_alongside_prop_without_size_is_silently_ignored():
+    """Documents the underlying Matplotlib behaviour the fix works around:
+    with both `fontsize=` and `prop=` (without `size` in `prop`), the legend
+    text falls back to rcParams["legend.fontsize"], not the requested size."""
+    fig = Figure()
+    axes, handles, labels = _plot_one_series(fig)
+    legend = axes.legend(handles, labels, fontsize=22, prop={"family": "DejaVu Sans"})
+    assert legend.get_texts()[0].get_fontsize() != 22

--- a/tests/gui/test_chart_editor_legend_font_size.py
+++ b/tests/gui/test_chart_editor_legend_font_size.py
@@ -1,0 +1,50 @@
+"""Pure-matplotlib regression test for the legend font-size bug in
+ChartEditor.update_chart (mirrors test_chart_editor_background_rendering.py):
+Matplotlib silently ignores a `.legend(fontsize=...)` kwarg whenever `prop=`
+is also passed, so the configured legend font size only takes effect if it's
+merged into the `prop` dict alongside `family`."""
+from matplotlib.figure import Figure
+
+
+def render_legend_broken(fig, axes, handles, labels, font_size, font_family):
+    """The pre-fix `.legend(...)` call: `fontsize=` and `prop={"family": ...}`
+    passed together."""
+    return axes.legend(handles, labels, fontsize=font_size, prop={"family": font_family})
+
+
+def render_legend_fixed(fig, axes, handles, labels, font_size, font_family):
+    """Mirrors the corrected `.legend(...)` call in ChartEditor.update_chart:
+    the size is merged into `prop` instead of passed as a separate
+    `fontsize=` kwarg."""
+    return axes.legend(handles, labels, prop={"family": font_family, "size": font_size})
+
+
+def _plot_one_series(fig):
+    axes = fig.add_subplot(111)
+    axes.plot([1, 2, 3], [1, 2, 3], label="Series 1")
+    return axes, *axes.get_legend_handles_labels()
+
+
+def test_broken_call_ignores_configured_font_size_when_prop_also_set():
+    """Documents the bug: with both `fontsize=` and `prop=` (without `size`
+    in `prop`), the legend text falls back to rcParams["legend.fontsize"],
+    not the configured size."""
+    fig = Figure()
+    axes, handles, labels = _plot_one_series(fig)
+    legend = render_legend_broken(fig, axes, handles, labels, 22, "DejaVu Sans")
+    assert legend.get_texts()[0].get_fontsize() != 22
+
+
+def test_fixed_call_applies_configured_font_size_with_font_family_set():
+    fig = Figure()
+    axes, handles, labels = _plot_one_series(fig)
+    legend = render_legend_fixed(fig, axes, handles, labels, 22, "DejaVu Sans")
+    assert legend.get_texts()[0].get_fontsize() == 22
+    assert legend.get_texts()[0].get_fontfamily() == ["DejaVu Sans"]
+
+
+def test_fixed_call_applies_default_font_size_of_ten():
+    fig = Figure()
+    axes, handles, labels = _plot_one_series(fig)
+    legend = render_legend_fixed(fig, axes, handles, labels, 10, "DejaVu Sans")
+    assert legend.get_texts()[0].get_fontsize() == 10

--- a/tests/gui/test_chart_editor_legend_outside_layout.py
+++ b/tests/gui/test_chart_editor_legend_outside_layout.py
@@ -1,0 +1,50 @@
+"""Pure-matplotlib regression test for the outside-legend clipping bug in
+ChartEditor.update_chart (mirrors test_chart_editor_background_rendering.py
+and test_chart_editor_legend_font_size.py).
+
+A legend placed outside the axes via `bbox_to_anchor` (the Outside Right/
+Top/Bottom/Custom positions -- see resolve_legend_placement) sits past the
+axes' own bounding box, so `fig.tight_layout()` must run *after* the legend
+exists for Matplotlib to shrink the axes and make room for it. Before the
+fix, `tight_layout()` in `update_chart` only ran when a secondary axis was
+present, so a single-axis chart with an outside/custom legend never got any
+`tight_layout()` call at all -- the legend was clipped by the figure
+boundary and never fully on-figure.
+"""
+from matplotlib.backends.backend_agg import FigureCanvasAgg
+from matplotlib.figure import Figure
+
+
+def _plot_and_place_legend_outside(fig):
+    axes = fig.add_subplot(111)
+    axes.plot([1, 2, 3], [1, 2, 3], label="Series One")
+    handles, labels = axes.get_legend_handles_labels()
+    legend = axes.legend(handles, labels, loc="center left", bbox_to_anchor=(1.02, 0.5))
+    return axes, legend
+
+
+def _legend_window_extent(fig, legend):
+    canvas = FigureCanvasAgg(fig)
+    canvas.draw()
+    renderer = canvas.get_renderer()
+    return legend.get_window_extent(renderer)
+
+
+def test_outside_legend_is_clipped_without_tight_layout_after_legend():
+    """Documents the bug: no tight_layout() call at all (the single-axis
+    case pre-fix) leaves the outside legend clipped by the figure edge."""
+    fig = Figure(figsize=(6, 4))
+    _axes, legend = _plot_and_place_legend_outside(fig)
+    bbox = _legend_window_extent(fig, legend)
+    assert bbox.x1 > fig.bbox.width
+
+
+def test_outside_legend_fits_when_tight_layout_runs_after_legend_added():
+    """Mirrors the fixed `update_chart` sequence: tight_layout() is called
+    (again, if needed) after the legend is added, so Matplotlib shrinks the
+    axes to make room for it and the legend lands fully on-figure."""
+    fig = Figure(figsize=(6, 4))
+    _axes, legend = _plot_and_place_legend_outside(fig)
+    fig.tight_layout()
+    bbox = _legend_window_extent(fig, legend)
+    assert bbox.x1 <= fig.bbox.width

--- a/tests/gui/test_chart_editor_legend_outside_layout.py
+++ b/tests/gui/test_chart_editor_legend_outside_layout.py
@@ -1,6 +1,5 @@
-"""Pure-matplotlib regression test for the outside-legend clipping bug in
-ChartEditor.update_chart (mirrors test_chart_editor_background_rendering.py
-and test_chart_editor_legend_font_size.py).
+"""Regression test for the outside-legend clipping bug in
+ChartEditor.update_chart.
 
 A legend placed outside the axes via `bbox_to_anchor` (the Outside Right/
 Top/Bottom/Custom positions -- see resolve_legend_placement) sits past the
@@ -10,9 +9,14 @@ fix, `tight_layout()` in `update_chart` only ran when a secondary axis was
 present, so a single-axis chart with an outside/custom legend never got any
 `tight_layout()` call at all -- the legend was clipped by the figure
 boundary and never fully on-figure.
-"""
+
+This exercises the real `apply_layout_with_legend` helper used by
+`ChartEditorWidget.update_chart` (extracted so it can be tested without a
+live QApplication/canvas)."""
 from matplotlib.backends.backend_agg import FigureCanvasAgg
 from matplotlib.figure import Figure
+
+from pandaplot.gui.components.tabs.chart.chart_editor import apply_layout_with_legend
 
 
 def _plot_and_place_legend_outside(fig):
@@ -30,21 +34,45 @@ def _legend_window_extent(fig, legend):
     return legend.get_window_extent(renderer)
 
 
-def test_outside_legend_is_clipped_without_tight_layout_after_legend():
-    """Documents the bug: no tight_layout() call at all (the single-axis
-    case pre-fix) leaves the outside legend clipped by the figure edge."""
+def test_outside_legend_is_clipped_without_any_tight_layout_call():
+    """Documents the bug: on a single-axis chart the pre-fix code (gated on
+    axes2 being present) never called tight_layout() at all, leaving the
+    outside legend clipped by the figure edge."""
     fig = Figure(figsize=(6, 4))
     _axes, legend = _plot_and_place_legend_outside(fig)
     bbox = _legend_window_extent(fig, legend)
     assert bbox.x1 > fig.bbox.width
 
 
-def test_outside_legend_fits_when_tight_layout_runs_after_legend_added():
-    """Mirrors the fixed `update_chart` sequence: tight_layout() is called
-    (again, if needed) after the legend is added, so Matplotlib shrinks the
-    axes to make room for it and the legend lands fully on-figure."""
+def test_apply_layout_with_legend_fits_outside_legend_on_single_axis_chart():
+    """Mirrors the fixed `update_chart` sequence for a single-axis chart with
+    an outside legend (no secondary axis, so the old axes2-gated call would
+    never run): tight_layout() must still run so the legend lands fully
+    on-figure."""
     fig = Figure(figsize=(6, 4))
     _axes, legend = _plot_and_place_legend_outside(fig)
-    fig.tight_layout()
+    apply_layout_with_legend(fig, tight_layout_kwargs={}, legend_placed_outside=True)
     bbox = _legend_window_extent(fig, legend)
     assert bbox.x1 <= fig.bbox.width
+
+
+def test_apply_layout_with_legend_runs_tight_layout_twice_when_legend_outside():
+    """The extra pass is what accounts for the legend's own out-of-axes
+    extent (unknown to Matplotlib on the first pass)."""
+    fig = Figure(figsize=(6, 4))
+    _plot_and_place_legend_outside(fig)
+    calls = []
+    fig.tight_layout = lambda **kwargs: calls.append(kwargs)
+    apply_layout_with_legend(fig, tight_layout_kwargs={"pad": 2.0}, legend_placed_outside=True)
+    assert calls == [{"pad": 2.0}, {"pad": 2.0}]
+
+
+def test_apply_layout_with_legend_runs_tight_layout_once_when_legend_inside():
+    fig = Figure(figsize=(6, 4))
+    axes = fig.add_subplot(111)
+    axes.plot([1, 2, 3], [1, 2, 3], label="Series One")
+    axes.legend()
+    calls = []
+    fig.tight_layout = lambda **kwargs: calls.append(kwargs)
+    apply_layout_with_legend(fig, tight_layout_kwargs={"pad": 2.0}, legend_placed_outside=False)
+    assert calls == [{"pad": 2.0}]

--- a/tests/gui/test_chart_editor_legend_placement.py
+++ b/tests/gui/test_chart_editor_legend_placement.py
@@ -1,0 +1,28 @@
+"""Unit tests for resolve_legend_placement(), the pure helper that maps a
+legend position (including the new outside/custom options) to matplotlib's
+Legend `loc`/`bbox_to_anchor` kwargs."""
+from pandaplot.gui.components.tabs.chart.chart_editor import resolve_legend_placement
+
+
+def test_existing_inside_position_passes_loc_only():
+    assert resolve_legend_placement("upper right", 1.02, 0.5, "center left") == {"loc": "upper right"}
+
+
+def test_outside_right_uses_fixed_loc_and_bbox_anchor():
+    result = resolve_legend_placement("outside_right", 1.02, 0.5, "center left")
+    assert result == {"loc": "center left", "bbox_to_anchor": (1.02, 0.5)}
+
+
+def test_outside_top_uses_fixed_loc_and_bbox_anchor():
+    result = resolve_legend_placement("outside_top", 1.02, 0.5, "center left")
+    assert result == {"loc": "lower center", "bbox_to_anchor": (0.5, 1.02)}
+
+
+def test_outside_bottom_uses_fixed_loc_and_bbox_anchor():
+    result = resolve_legend_placement("outside_bottom", 1.02, 0.5, "center left")
+    assert result == {"loc": "upper center", "bbox_to_anchor": (0.5, -0.08)}
+
+
+def test_custom_uses_the_given_anchor_and_xy():
+    result = resolve_legend_placement("custom", 0.3, 0.7, "upper left")
+    assert result == {"loc": "upper left", "bbox_to_anchor": (0.3, 0.7)}

--- a/tests/gui/test_chart_editor_range_helpers.py
+++ b/tests/gui/test_chart_editor_range_helpers.py
@@ -69,3 +69,24 @@ def test_combines_min_max_across_multiple_series():
         DataSeries(dataset_id="ds2", x_column="x", y_column="y"),
     ]
     assert compute_axis_data_range(project, series, "x") == (-5.0, 2.0)
+
+
+def test_positive_only_excludes_non_positive_values_from_range():
+    """Log-scaled axes must ignore zero/negative data points -- matplotlib's
+    own autoscale does the same when computing log-scale view limits."""
+    ds = _make_dataset("ds1", x=[1, 2, 3], y=[-5, 10, 20])
+    project = _FakeProject([ds])
+    series = [DataSeries(dataset_id="ds1", x_column="x", y_column="y")]
+    assert compute_axis_data_range(project, series, "y", positive_only=True) == (10.0, 20.0)
+    assert compute_axis_data_range(project, series, "y") == (-5.0, 20.0)
+    assert compute_axis_data_range(project, series, "y", positive_only=False) == (-5.0, 20.0)
+
+
+def test_positive_only_series_with_all_non_positive_values_contributes_nothing():
+    """If every value in the only series is <= 0 and positive_only=True,
+    that series contributes no range at all -- matching the existing 'no
+    resolvable data' contract of returning None."""
+    ds = _make_dataset("ds1", x=[1, 2, 3], y=[-5, 0, -1])
+    project = _FakeProject([ds])
+    series = [DataSeries(dataset_id="ds1", x_column="x", y_column="y")]
+    assert compute_axis_data_range(project, series, "y", positive_only=True) is None

--- a/tests/gui/test_chart_editor_range_helpers.py
+++ b/tests/gui/test_chart_editor_range_helpers.py
@@ -1,0 +1,71 @@
+"""Unit tests for compute_axis_data_range(), the pure helper that computes
+the (min, max) of all series data plotted against a given axis -- used to
+populate the Axes tab's Range card in both Auto (disabled, for reference)
+and the moment of switching into Manual (recompute-fresh)."""
+import numpy as np
+import pytest
+
+from pandaplot.gui.components.tabs.chart.chart_editor import compute_axis_data_range
+from pandaplot.models.project.items.chart import DataSeries, YAxis
+from pandaplot.models.project.items.dataset import Dataset
+
+
+class _FakeProject:
+    def __init__(self, datasets):
+        self._datasets = {d.id: d for d in datasets}
+
+    def find_item(self, item_id):
+        return self._datasets.get(item_id)
+
+
+def _make_dataset(id_, x, y):
+    import pandas as pd
+    ds = Dataset(id=id_, name=id_)
+    ds.data = pd.DataFrame({"x": x, "y": y})
+    return ds
+
+
+def test_computes_min_max_across_all_series_on_the_x_axis():
+    ds = _make_dataset("ds1", x=[1, 5, 3], y=[10, 20, 30])
+    project = _FakeProject([ds])
+    series = [DataSeries(dataset_id="ds1", x_column="x", y_column="y")]
+    assert compute_axis_data_range(project, series, "x") == (1.0, 5.0)
+
+
+def test_computes_min_max_for_y_axis():
+    ds = _make_dataset("ds1", x=[1, 2], y=[10, 20])
+    project = _FakeProject([ds])
+    series = [DataSeries(dataset_id="ds1", x_column="x", y_column="y")]
+    assert compute_axis_data_range(project, series, "y") == (10.0, 20.0)
+
+
+def test_y2_only_includes_secondary_axis_series():
+    ds = _make_dataset("ds1", x=[1, 2], y=[10, 20])
+    project = _FakeProject([ds])
+    primary = DataSeries(dataset_id="ds1", x_column="x", y_column="y", y_axis=YAxis.PRIMARY)
+    secondary = DataSeries(dataset_id="ds1", x_column="x", y_column="y", y_axis=YAxis.SECONDARY)
+    secondary.y_column = "y"
+    assert compute_axis_data_range(project, [primary, secondary], "y2") == (10.0, 20.0)
+    assert compute_axis_data_range(project, [primary, secondary], "y") == (10.0, 20.0)
+
+
+def test_returns_none_when_no_series_have_resolvable_data():
+    project = _FakeProject([])
+    series = [DataSeries(dataset_id="missing", x_column="x", y_column="y")]
+    assert compute_axis_data_range(project, series, "x") is None
+
+
+def test_returns_none_for_empty_series_list():
+    project = _FakeProject([])
+    assert compute_axis_data_range(project, [], "x") is None
+
+
+def test_combines_min_max_across_multiple_series():
+    ds1 = _make_dataset("ds1", x=[1, 2], y=[10, 20])
+    ds2 = _make_dataset("ds2", x=[-5, 0], y=[100, 200])
+    project = _FakeProject([ds1, ds2])
+    series = [
+        DataSeries(dataset_id="ds1", x_column="x", y_column="y"),
+        DataSeries(dataset_id="ds2", x_column="x", y_column="y"),
+    ]
+    assert compute_axis_data_range(project, series, "x") == (-5.0, 2.0)

--- a/tests/gui/test_chart_editor_scale_helpers.py
+++ b/tests/gui/test_chart_editor_scale_helpers.py
@@ -1,0 +1,15 @@
+"""Unit tests for resolve_scale_kwargs(), the pure helper that decides
+whether a log `base` kwarg should be passed to Axes.set_xscale/set_yscale."""
+from pandaplot.gui.components.tabs.chart.chart_editor import resolve_scale_kwargs
+
+
+def test_linear_scale_has_no_base_kwarg():
+    assert resolve_scale_kwargs("linear", 10.0) == {}
+
+
+def test_log_scale_passes_base_kwarg():
+    assert resolve_scale_kwargs("log", 2.0) == {"base": 2.0}
+
+
+def test_log_scale_with_custom_base_between_zero_and_one():
+    assert resolve_scale_kwargs("log", 0.5) == {"base": 0.5}

--- a/tests/gui/test_chart_editor_scale_helpers.py
+++ b/tests/gui/test_chart_editor_scale_helpers.py
@@ -1,5 +1,10 @@
 """Unit tests for resolve_scale_kwargs(), the pure helper that decides
 whether a log `base` kwarg should be passed to Axes.set_xscale/set_yscale."""
+
+import matplotlib
+
+matplotlib.use("Agg")  # headless backend, no display/Qt required
+
 from pandaplot.gui.components.tabs.chart.chart_editor import resolve_scale_kwargs
 
 
@@ -13,3 +18,12 @@ def test_log_scale_passes_base_kwarg():
 
 def test_log_scale_with_custom_base_between_zero_and_one():
     assert resolve_scale_kwargs("log", 0.5) == {"base": 0.5}
+
+
+def test_log_scale_with_non_positive_base_falls_back_to_ten():
+    assert resolve_scale_kwargs("log", -2.0) == {"base": 10.0}
+    assert resolve_scale_kwargs("log", 0.0) == {"base": 10.0}
+
+
+def test_log_scale_with_base_one_falls_back_to_ten():
+    assert resolve_scale_kwargs("log", 1.0) == {"base": 10.0}

--- a/tests/gui/test_chart_editor_title_helpers.py
+++ b/tests/gui/test_chart_editor_title_helpers.py
@@ -90,3 +90,15 @@ def test_title_and_subtitle_font_family_default_to_dejavu_sans():
     apply_chart_title(axes, title="My Chart", subtitle="n = 42", title_font_size=14, subtitle_font_size=10)
     assert axes.figure._suptitle.get_fontfamily() == ["DejaVu Sans"]
     assert axes.title.get_fontfamily() == ["DejaVu Sans"]
+
+
+def test_mathtext_title_text_passes_through_unmodified():
+    axes = _make_axes()
+    apply_chart_title(axes, title=r"Energy $E = mc^2$", subtitle="", title_font_size=14, subtitle_font_size=12)
+    assert axes.figure.get_suptitle() == r"Energy $E = mc^2$"
+
+
+def test_mathtext_subtitle_text_passes_through_unmodified():
+    axes = _make_axes()
+    apply_chart_title(axes, title="t", subtitle=r"$\alpha = 0.05$", title_font_size=14, subtitle_font_size=10)
+    assert axes.get_title() == r"$\alpha = 0.05$"

--- a/tests/gui/test_chart_editor_title_helpers.py
+++ b/tests/gui/test_chart_editor_title_helpers.py
@@ -65,3 +65,28 @@ def test_title_and_subtitle_color_default_to_black():
     apply_chart_title(axes, title="My Chart", subtitle="n = 42", title_font_size=14, subtitle_font_size=10)
     assert axes.figure._suptitle.get_color() == "#000000"
     assert axes.title.get_color() == "#000000"
+
+
+def test_title_font_family_is_applied_to_the_suptitle():
+    axes = _make_axes()
+    apply_chart_title(
+        axes, title="My Chart", subtitle="", title_font_size=14, subtitle_font_size=12,
+        title_font_family="Georgia",
+    )
+    assert axes.figure._suptitle.get_fontfamily() == ["Georgia"]
+
+
+def test_subtitle_font_family_is_applied_to_the_axes_title():
+    axes = _make_axes()
+    apply_chart_title(
+        axes, title="My Chart", subtitle="n = 42", title_font_size=14, subtitle_font_size=10,
+        subtitle_font_family="Georgia",
+    )
+    assert axes.title.get_fontfamily() == ["Georgia"]
+
+
+def test_title_and_subtitle_font_family_default_to_dejavu_sans():
+    axes = _make_axes()
+    apply_chart_title(axes, title="My Chart", subtitle="n = 42", title_font_size=14, subtitle_font_size=10)
+    assert axes.figure._suptitle.get_fontfamily() == ["DejaVu Sans"]
+    assert axes.title.get_fontfamily() == ["DejaVu Sans"]

--- a/tests/gui/test_font_family_options.py
+++ b/tests/gui/test_font_family_options.py
@@ -1,0 +1,23 @@
+"""Unit tests for list_available_font_families(), the pure helper backing
+every new font-family QComboBox added in this plan."""
+from pandaplot.gui.components.common.font_family_options import list_available_font_families
+
+
+def test_returns_nonempty_sorted_deduplicated_pairs():
+    families = list_available_font_families()
+    assert len(families) > 0
+    names = [label for label, _value in families]
+    assert names == sorted(names)
+    assert len(names) == len(set(names))
+
+
+def test_every_item_is_a_label_value_pair_with_matching_label_and_value():
+    families = list_available_font_families()
+    for label, value in families:
+        assert label == value
+        assert isinstance(label, str) and label
+
+
+def test_dejavu_sans_is_always_present():
+    families = list_available_font_families()
+    assert "DejaVu Sans" in [label for label, _value in families]

--- a/tests/gui/test_style_tab_axes_colors.py
+++ b/tests/gui/test_style_tab_axes_colors.py
@@ -1,0 +1,98 @@
+"""Regression tests for two ordering bugs in StyleTab's Axes-section Colors
+card (style_tab.py), moved here from tests/gui/test_axes_tab.py in Task 6
+when the Colors card itself moved from AxesTab into StyleTab's "Axes"
+section.
+
+1. `load_chart_style` must set match-toggle checked state BEFORE loading
+   swatch colors from `chart.config`. `ToggleSwitch.setChecked` emits
+   `toggled` unconditionally, and the toggled handler
+   (`_on_axis_style_match_x_colors_toggled`) pre-fills its swatches from
+   X's *current* color whenever the new state is "not matching" -- this
+   would silently clobber a saved custom color the moment a chart with
+   `y_match_x_colors=False` loaded, if colors were loaded first.
+
+2. `_on_copy_axis_style` has the same ordering requirement: it must set
+   the target's match toggles BEFORE copying the source axis's colors
+   into the target, or the toggled handler's pre-fill would overwrite the
+   just-copied colors with X's instead.
+"""
+import types
+
+import pytest
+from PySide6.QtWidgets import QApplication
+
+from pandaplot.gui.components.sidebar.chart.tabs.style_tab import StyleTab
+from pandaplot.models.project.items.chart import Chart
+
+
+@pytest.fixture(scope="module", autouse=True)
+def qapp():
+    app = QApplication.instance() or QApplication([])
+    yield app
+
+
+def _make_app_context():
+    return types.SimpleNamespace(app_state=types.SimpleNamespace(current_project=None))
+
+
+def test_load_preserves_custom_y_colors_when_not_matching_x():
+    """Loading a chart where Y opted out of matching X's colors, with its
+    own custom spine/tick colors saved, must NOT have those colors
+    replaced by X's colors just because the chart loaded."""
+    chart = Chart(name="Test Chart")
+    chart.update_config({
+        "x_spine_color": "#111111",
+        "x_major_tick_color": "#111111",
+        "x_minor_tick_color": "#111111",
+        "x_tick_label_color": "#111111",
+        "y_match_x_colors": False,
+        "y_spine_color": "#abcdef",
+        "y_major_tick_color": "#abcdef",
+        "y_minor_tick_color": "#abcdef",
+        "y_tick_label_color": "#abcdef",
+    })
+
+    tab = StyleTab(_make_app_context())
+    tab.load_chart_style(chart)
+
+    y_form = tab.axes_style_forms["y"]
+    assert y_form["match_x_colors_toggle"].isChecked() is False
+    assert y_form["spine_color_row"].currentColor() == "#abcdef"
+    assert y_form["major_tick_color_row"].currentColor() == "#abcdef"
+    assert y_form["minor_tick_color_row"].currentColor() == "#abcdef"
+    assert y_form["tick_color_row"].currentColor() == "#abcdef"
+
+
+def test_copy_axis_style_copies_source_colors_not_x_colors():
+    """Copying Y2 (unmatched, with custom colors) into Y must leave Y with
+    Y2's colors -- not X's -- even though copying flips Y's match toggle."""
+    chart = Chart(name="Test Chart")
+    chart.update_config({
+        "x_spine_color": "#111111",
+        "x_major_tick_color": "#111111",
+        "x_minor_tick_color": "#111111",
+        "x_tick_label_color": "#111111",
+        "y2_match_x_colors": False,
+        "y2_spine_color": "#00ff00",
+        "y2_major_tick_color": "#00ff00",
+        "y2_minor_tick_color": "#00ff00",
+        "y2_tick_label_color": "#00ff00",
+        # Y starts out matching X (default), which is the state being
+        # flipped away from during the copy.
+    })
+    chart.add_data_series(dataset_id="ds1", x_column="x", y_column="y", y_axis="secondary")
+
+    tab = StyleTab(_make_app_context())
+    tab.load_chart_style(chart)
+
+    # Sanity check: Y starts out matching X, as loaded.
+    y_form = tab.axes_style_forms["y"]
+    assert y_form["match_x_colors_toggle"].isChecked() is True
+
+    tab._on_copy_axis_style("y2")
+
+    assert y_form["match_x_colors_toggle"].isChecked() is False
+    assert y_form["spine_color_row"].currentColor() == "#00ff00"
+    assert y_form["major_tick_color_row"].currentColor() == "#00ff00"
+    assert y_form["minor_tick_color_row"].currentColor() == "#00ff00"
+    assert y_form["tick_color_row"].currentColor() == "#00ff00"

--- a/tests/gui/test_style_tab_axis_selector_refresh.py
+++ b/tests/gui/test_style_tab_axis_selector_refresh.py
@@ -1,0 +1,52 @@
+"""Regression test for a stale-selection bug in
+StyleTab.refresh_axis_style_selector (style_tab.py): it rebuilds the Axes
+selector combo with `blockSignals(True)` around `setCurrentIndex`, so
+`_show_axis_style_form` never fires when the selection is forced back to "X"
+(e.g. the user had Y2 selected, then the last secondary-axis series is
+removed). The combo would show "X" while the Y2 form stayed visible."""
+import types
+
+import pytest
+from PySide6.QtWidgets import QApplication
+
+from pandaplot.gui.components.sidebar.chart.tabs.style_tab import StyleTab
+from pandaplot.models.project.items.chart import Chart, DataSeries, YAxis
+
+
+@pytest.fixture(scope="module", autouse=True)
+def qapp():
+    app = QApplication.instance() or QApplication([])
+    yield app
+
+
+def _make_app_context():
+    return types.SimpleNamespace(app_state=types.SimpleNamespace(current_project=None))
+
+
+def test_refresh_axis_style_selector_shows_x_form_when_y2_series_removed():
+    chart = Chart(name="Test Chart")
+    chart.data_series.append(
+        DataSeries(dataset_id="ds1", y_axis=YAxis.SECONDARY)
+    )
+
+    tab = StyleTab(_make_app_context())
+    tab.load_chart_style(chart)
+
+    # Simulate the user selecting Y2 in the Axes selector while it still has
+    # a secondary-axis series. `ValueComboBox.setCurrentValue()` is a silent
+    # programmatic setter (blocks signals), so drive the combo's native
+    # `setCurrentIndex` directly -- like a real click would -- to fire
+    # `currentIndexChanged` -> `currentValueChanged` -> `_show_axis_style_form`.
+    selector = tab.axes_style_selector
+    selector.setCurrentIndex(selector.findData("y2"))
+    assert tab.axes_style_forms["y2"]["widget"].isHidden() is False
+    assert tab.axes_style_forms["x"]["widget"].isHidden() is True
+
+    # Now the last secondary-axis series is removed and the panel refreshes
+    # the selector (chart_properties_panel.py's refresh_axis_selectors path).
+    chart.data_series.clear()
+    tab.refresh_axis_style_selector(chart)
+
+    assert tab.axes_style_selector.currentValue() == "x"
+    assert tab.axes_style_forms["x"]["widget"].isHidden() is False
+    assert tab.axes_style_forms["y2"]["widget"].isHidden() is True

--- a/tests/models/test_chart_style_axes_legend_config.py
+++ b/tests/models/test_chart_style_axes_legend_config.py
@@ -591,3 +591,22 @@ def test_log_base_round_trips_through_serialization():
     assert restored.config["x_log_base"] == 2.0
     assert restored.config["y_log_base"] == 2.0
     assert restored.config["y2_log_base"] == math.e
+
+
+def test_axis_title_style_fields_default_when_missing():
+    chart = Chart(name="Test Chart")
+    assert chart.config.get("x_font_family", "DejaVu Sans") == "DejaVu Sans"
+    assert chart.config.get("x_title_bold", False) is False
+    assert chart.config.get("x_title_italic", False) is False
+
+
+def test_axis_title_style_fields_round_trip_through_serialization():
+    chart = Chart(name="Test Chart")
+    chart.config["y_font_family"] = "Georgia"
+    chart.config["y_title_bold"] = True
+    chart.config["y_title_italic"] = True
+    data = chart.to_dict()
+    restored = Chart.from_dict(data)
+    assert restored.config["y_font_family"] == "Georgia"
+    assert restored.config["y_title_bold"] is True
+    assert restored.config["y_title_italic"] is True

--- a/tests/models/test_chart_style_axes_legend_config.py
+++ b/tests/models/test_chart_style_axes_legend_config.py
@@ -570,3 +570,16 @@ def test_show_minor_grid_round_trips_through_serialization():
     assert restored.config["x_show_minor_grid"] is True
     assert restored.config["y_show_minor_grid"] is True
     assert restored.config["y2_show_minor_grid"] is False
+
+
+def test_log_base_defaults_to_ten_when_missing():
+    chart = Chart(name="Test Chart")
+    assert chart.config.get("x_log_base", 10.0) == 10.0
+
+
+def test_log_base_round_trips_through_serialization():
+    chart = Chart(name="Test Chart")
+    chart.config["x_log_base"] = 2.0
+    data = chart.to_dict()
+    restored = Chart.from_dict(data)
+    assert restored.config["x_log_base"] == 2.0

--- a/tests/models/test_chart_style_axes_legend_config.py
+++ b/tests/models/test_chart_style_axes_legend_config.py
@@ -610,3 +610,25 @@ def test_axis_title_style_fields_round_trip_through_serialization():
     assert restored.config["y_font_family"] == "Georgia"
     assert restored.config["y_title_bold"] is True
     assert restored.config["y_title_italic"] is True
+
+
+def test_tick_label_style_fields_default_when_missing():
+    chart = Chart(name="Test Chart")
+    assert chart.config.get("x_tick_label_font_size", 10) == 10
+    assert chart.config.get("x_tick_label_font_family", "DejaVu Sans") == "DejaVu Sans"
+    assert chart.config.get("x_tick_label_bold", False) is False
+    assert chart.config.get("x_tick_label_italic", False) is False
+
+
+def test_tick_label_style_fields_round_trip_through_serialization():
+    chart = Chart(name="Test Chart")
+    chart.config["y_tick_label_font_size"] = 14
+    chart.config["y_tick_label_font_family"] = "Georgia"
+    chart.config["y_tick_label_bold"] = True
+    chart.config["y_tick_label_italic"] = True
+    data = chart.to_dict()
+    restored = Chart.from_dict(data)
+    assert restored.config["y_tick_label_font_size"] == 14
+    assert restored.config["y_tick_label_font_family"] == "Georgia"
+    assert restored.config["y_tick_label_bold"] is True
+    assert restored.config["y_tick_label_italic"] is True

--- a/tests/models/test_chart_style_axes_legend_config.py
+++ b/tests/models/test_chart_style_axes_legend_config.py
@@ -542,6 +542,22 @@ def test_show_minor_grid_defaults_to_false_for_all_axes():
         assert axis.get_tick_params(which="minor")["gridOn"] is False
 
 
+def test_title_and_subtitle_font_family_default_when_missing():
+    chart = Chart(name="Test Chart")
+    assert chart.config.get("title_font_family", "DejaVu Sans") == "DejaVu Sans"
+    assert chart.config.get("subtitle_font_family", "DejaVu Sans") == "DejaVu Sans"
+
+
+def test_title_font_family_round_trips_through_serialization():
+    chart = Chart(name="Test Chart")
+    chart.config["title_font_family"] = "Georgia"
+    chart.config["subtitle_font_family"] = "Verdana"
+    data = chart.to_dict()
+    restored = Chart.from_dict(data)
+    assert restored.config["title_font_family"] == "Georgia"
+    assert restored.config["subtitle_font_family"] == "Verdana"
+
+
 def test_show_minor_grid_round_trips_through_serialization():
     chart = Chart(name="Test Chart")
     chart.update_config({

--- a/tests/models/test_chart_style_axes_legend_config.py
+++ b/tests/models/test_chart_style_axes_legend_config.py
@@ -620,6 +620,27 @@ def test_tick_label_style_fields_default_when_missing():
     assert chart.config.get("x_tick_label_italic", False) is False
 
 
+def test_legend_custom_placement_fields_default_when_missing():
+    chart = Chart(name="Test Chart")
+    assert chart.config.get("legend_custom_x", 1.02) == 1.02
+    assert chart.config.get("legend_custom_y", 0.5) == 0.5
+    assert chart.config.get("legend_custom_anchor", "center left") == "center left"
+
+
+def test_legend_custom_placement_fields_round_trip_through_serialization():
+    chart = Chart(name="Test Chart")
+    chart.config["legend_position"] = "custom"
+    chart.config["legend_custom_x"] = 0.25
+    chart.config["legend_custom_y"] = 0.75
+    chart.config["legend_custom_anchor"] = "upper left"
+    data = chart.to_dict()
+    restored = Chart.from_dict(data)
+    assert restored.config["legend_position"] == "custom"
+    assert restored.config["legend_custom_x"] == 0.25
+    assert restored.config["legend_custom_y"] == 0.75
+    assert restored.config["legend_custom_anchor"] == "upper left"
+
+
 def test_tick_label_style_fields_round_trip_through_serialization():
     chart = Chart(name="Test Chart")
     chart.config["y_tick_label_font_size"] = 14

--- a/tests/models/test_chart_style_axes_legend_config.py
+++ b/tests/models/test_chart_style_axes_legend_config.py
@@ -4,6 +4,8 @@ Style/Axes/Legend sidebar tabs (per-axis grid, scale, font size,
 axis limits, tick configuration, legend styling, series alpha).
 """
 
+import math
+
 import pytest
 from matplotlib.figure import Figure
 from PySide6.QtWidgets import QApplication
@@ -579,7 +581,13 @@ def test_log_base_defaults_to_ten_when_missing():
 
 def test_log_base_round_trips_through_serialization():
     chart = Chart(name="Test Chart")
-    chart.config["x_log_base"] = 2.0
+    chart.update_config({
+        "x_log_base": 2.0,
+        "y_log_base": 2.0,
+        "y2_log_base": math.e,
+    })
     data = chart.to_dict()
     restored = Chart.from_dict(data)
     assert restored.config["x_log_base"] == 2.0
+    assert restored.config["y_log_base"] == 2.0
+    assert restored.config["y2_log_base"] == math.e

--- a/tests/models/test_chart_style_axes_legend_config.py
+++ b/tests/models/test_chart_style_axes_legend_config.py
@@ -653,3 +653,16 @@ def test_tick_label_style_fields_round_trip_through_serialization():
     assert restored.config["y_tick_label_font_family"] == "Georgia"
     assert restored.config["y_tick_label_bold"] is True
     assert restored.config["y_tick_label_italic"] is True
+
+
+def test_legend_font_family_defaults_when_missing():
+    chart = Chart(name="Test Chart")
+    assert chart.config.get("legend_font_family", "DejaVu Sans") == "DejaVu Sans"
+
+
+def test_legend_font_family_round_trips_through_serialization():
+    chart = Chart(name="Test Chart")
+    chart.config["legend_font_family"] = "Georgia"
+    data = chart.to_dict()
+    restored = Chart.from_dict(data)
+    assert restored.config["legend_font_family"] == "Georgia"


### PR DESCRIPTION
## Summary
Implements the 8-item Chart Properties Improvements design (docs/superpowers/specs/2026-07-28-chart-properties-improvements-design.md):
- Axis appearance (title/tick font, color) regrouped from the Axes tab into a new Style-tab "Axes" section
- Selectable log-scale base per axis (10, 2, e, custom)
- Axis range: Auto now shows live data min/max; Manual persists until an explicit Auto→Manual toggle
- Legend placement outside the plot area (presets) plus fully custom placement
- Font-family controls for chart title/subtitle, axis titles/ticks, and legend text
- LaTeX/mathtext pass-through verified, with UI hints on text fields

A final whole-branch review caught and fixed one regression (legend font size silently dropped when a font family was also set) plus four cross-task integration gaps (stale Style-tab axis form after Y2 disappears, Range spin box precision, Auto range not refreshing on Linear→Log switch, clipped outside-placed legends).

## Test plan
- [x] `pytest -q` — 695 passed, 4 pre-existing unrelated failures (scipy/matplotlib lazy-import startup tests, confirmed pre-existing on `main`)
- [x] Every new `chart.config` key has a default/round-trip test
- [x] Every new rendering helper has a headless (Agg backend) unit test
- [x] Manual verification substituted with scripted widget-level checks where noted in task reports (UI show/hide behavior)