### PR TITLE
Consistent title/scroll shell across all sidebar panels

### DIFF
--- a/docs/arch/05-gui-layer.md
+++ b/docs/arch/05-gui-layer.md
@@ -44,6 +44,10 @@ Icon-based left panel switcher. Each icon maps to a panel:
 
 `ConditionalPanelManager` listens to `UIEvents` and `ProjectEvents` to show/hide the correct panel automatically.
 
+### SidebarPanel (`gui/components/sidebar/panels/sidebar_panel.py`)
+
+Base class (extends `PWidget`) all 9 sidebar panels use for a consistent shell: a title pinned at the top via `_set_title()`, and a content area added via `_set_content(widget, scrollable=...)` — wrapped in a `QScrollArea` when `scrollable=True`, added directly otherwise (used by `ChartPropertiesPanel`, which scrolls per-tab instead, and `ProjectViewPanel`, whose tree scrolls natively).
+
 ### ProjectViewPanel
 
 Hierarchical tree view of all project items. Subscribes to:

--- a/pandaplot/gui/components/sidebar/analysis/analysis_panel.py
+++ b/pandaplot/gui/components/sidebar/analysis/analysis_panel.py
@@ -4,7 +4,6 @@ Analysis panel for mathematical operations on dataset columns.
 
 from typing import Any, Dict, Optional, override
 
-from PySide6.QtCore import Qt
 from PySide6.QtWidgets import (
     QCheckBox,
     QComboBox,
@@ -14,7 +13,6 @@ from PySide6.QtWidgets import (
     QLabel,
     QLineEdit,
     QPushButton,
-    QScrollArea,
     QSpinBox,
     QTextEdit,
     QVBoxLayout,

--- a/pandaplot/gui/components/sidebar/analysis/analysis_panel.py
+++ b/pandaplot/gui/components/sidebar/analysis/analysis_panel.py
@@ -23,14 +23,14 @@ from PySide6.QtWidgets import (
 
 from pandaplot.analysis import AnalysisEngine
 from pandaplot.commands.project.dataset.analysis_command import AnalysisCommand
-from pandaplot.gui.core.widget_extension import PWidget
+from pandaplot.gui.components.sidebar.panels.sidebar_panel import SidebarPanel
 from pandaplot.models.events import AnalysisEvents, DatasetEvents, DatasetOperationEvents, UIEvents
 from pandaplot.models.project.items import Dataset
 from pandaplot.models.state.app_context import AppContext
 from pandaplot.services.theme.theme_manager import ThemeManager
 
 
-class AnalysisPanel(PWidget):
+class AnalysisPanel(SidebarPanel):
     """
     Side panel for mathematical analysis operations on dataset columns.
     """
@@ -47,52 +47,42 @@ class AnalysisPanel(PWidget):
     def _init_ui(self):
         """Setup the user interface."""
         # Main layout with scroll area
-        main_layout = QVBoxLayout(self)
-        main_layout.setContentsMargins(8, 8, 8, 8)
-        main_layout.setSpacing(8)
-        
+        self._init_panel_layout()
+
         # Panel title
-        self.title_label = QLabel("📊 Analysis Operations")
-        main_layout.addWidget(self.title_label)
-        
-        # Scroll area for content
-        scroll_area = QScrollArea()
-        scroll_area.setWidgetResizable(True)
-        scroll_area.setHorizontalScrollBarPolicy(Qt.ScrollBarPolicy.ScrollBarAsNeeded)
-        scroll_area.setVerticalScrollBarPolicy(Qt.ScrollBarPolicy.ScrollBarAsNeeded)
-        
+        self._set_title("📊 Analysis Operations")
+
         # Content widget
         content_widget = QWidget()
         content_layout = QVBoxLayout(content_widget)
         content_layout.setContentsMargins(4, 4, 4, 4)
         content_layout.setSpacing(6)
-        
+
         # Analysis type selection
         self.create_analysis_type_section(content_layout)
-        
+
         # Column selection
         self.create_column_selection_section(content_layout)
-        
+
         # Parameters section
         self.create_parameters_section(content_layout)
-        
+
         # Data range section
         self.create_range_section(content_layout)
-        
+
         # Result configuration
         self.create_result_section(content_layout)
-        
+
         # Preview section
         self.create_preview_section(content_layout)
-        
+
         # Action buttons
         self.create_action_buttons(content_layout)
-        
+
         # Add stretch to push everything to top
         content_layout.addStretch()
-        
-        scroll_area.setWidget(content_widget)
-        main_layout.addWidget(scroll_area)
+
+        self._set_content(content_widget, scrollable=True)
     
     @override
     def _apply_theme(self):
@@ -133,16 +123,7 @@ class AnalysisPanel(PWidget):
         """)
         
         # Style title label
-        self.title_label.setStyleSheet(f"""
-            QLabel {{
-                font-size: 14px;
-                font-weight: bold;
-                color: {base_fg};
-                padding: 5px;
-                background-color: {card_border};
-                border-radius: 3px;
-            }}
-        """)
+        self.title_label.setStyleSheet(self.title_stylesheet(base_fg, card_border))
         
         # Style preview button
         self.preview_btn.setStyleSheet("""

--- a/pandaplot/gui/components/sidebar/chart/chart_properties_panel.py
+++ b/pandaplot/gui/components/sidebar/chart/chart_properties_panel.py
@@ -4,7 +4,6 @@ from typing import Optional, override
 from PySide6.QtCore import Qt
 from PySide6.QtWidgets import (
     QComboBox,
-    QLabel,
     QScrollArea,
     QTabWidget,
     QVBoxLayout,
@@ -18,14 +17,14 @@ from pandaplot.gui.components.sidebar.chart.tabs.chart_tab import ChartTab
 from pandaplot.gui.components.sidebar.chart.tabs.data_tab import DataTab
 from pandaplot.gui.components.sidebar.chart.tabs.legend_tab import LegendTab
 from pandaplot.gui.components.sidebar.chart.tabs.style_tab import StyleTab
-from pandaplot.gui.core.widget_extension import PWidget
+from pandaplot.gui.components.sidebar.panels.sidebar_panel import SidebarPanel
 from pandaplot.models.events import ChartEvents, ProjectEvents, UIEvents
 from pandaplot.models.project.items.chart import restore_chart_state, snapshot_chart_state
 from pandaplot.models.state.app_context import AppContext
 from pandaplot.services.theme.theme_manager import ThemeManager
 
 
-class ChartPropertiesPanel(PWidget):
+class ChartPropertiesPanel(SidebarPanel):
     """Side panel for configuring chart properties."""
 
     def __init__(self, app_context: AppContext, parent: Optional[QWidget] = None):
@@ -45,14 +44,10 @@ class ChartPropertiesPanel(PWidget):
     @override
     def _init_ui(self):
         """Set up the user interface."""
-        layout = QVBoxLayout(self)
-        layout.setContentsMargins(0, 0, 0, 0)
-        layout.setSpacing(0)
+        self._init_panel_layout()
 
         # Header
-        self.title_label = QLabel("📊 Chart Properties", self)
-        layout.addWidget(self.title_label)
-        layout.addSpacing(6)
+        self._set_title("📈 Chart Properties")
 
         # Tab widget for organizing chart properties. When the tab bar
         # doesn't fit the panel's width, `resizeEvent` swaps it for
@@ -63,7 +58,6 @@ class ChartPropertiesPanel(PWidget):
         self.tab_selector_combo.addItems(self._tab_titles)
         self.tab_selector_combo.setVisible(False)
         self.tab_selector_combo.currentIndexChanged.connect(self._on_tab_selector_combo_changed)
-        layout.addWidget(self.tab_selector_combo)
 
         self.tab_widget = QTabWidget(self)
         self.tab_widget.currentChanged.connect(self._on_tab_widget_current_changed)
@@ -109,13 +103,20 @@ class ChartPropertiesPanel(PWidget):
         self.legend_tab.configChanged.connect(self._on_any_tab_config_changed)
         self.tab_widget.addTab(self._wrap_in_scroll_area(self.legend_tab), "Legend")
 
-        layout.addWidget(self.tab_widget, stretch=1)
-
         # Footer: dirty-state indicator + Revert/Apply
         self.footer = DirtyFooter(self)
         self.footer.applyClicked.connect(self._on_apply)
         self.footer.revertClicked.connect(self._on_reset)
-        layout.addWidget(self.footer)
+
+        body_widget = QWidget(self)
+        body_layout = QVBoxLayout(body_widget)
+        body_layout.setContentsMargins(0, 6, 0, 0)
+        body_layout.setSpacing(0)
+        body_layout.addWidget(self.tab_selector_combo)
+        body_layout.addWidget(self.tab_widget, stretch=1)
+        body_layout.addWidget(self.footer)
+
+        self._set_content(body_widget, scrollable=False)
 
     def _wrap_in_scroll_area(self, widget: QWidget) -> QScrollArea:
         """Wrap a tab's content in a vertically-scrolling QScrollArea.
@@ -198,16 +199,7 @@ class ChartPropertiesPanel(PWidget):
         """)
         
         # Title label with improved styling
-        self.title_label.setStyleSheet(f"""
-            QLabel {{
-                font-size: 14px;
-                font-weight: bold;
-                color: {base_fg};
-                padding: 5px;
-                background-color: {card_border};
-                border-radius: 3px;
-            }}
-        """)
+        self.title_label.setStyleSheet(self.title_stylesheet(base_fg, card_border))
         
         # Tab widget with theme-aware colors
         self.tab_widget.setStyleSheet(f"""

--- a/pandaplot/gui/components/sidebar/chart/chart_properties_panel.py
+++ b/pandaplot/gui/components/sidebar/chart/chart_properties_panel.py
@@ -110,7 +110,7 @@ class ChartPropertiesPanel(SidebarPanel):
 
         body_widget = QWidget(self)
         body_layout = QVBoxLayout(body_widget)
-        body_layout.setContentsMargins(0, 6, 0, 0)
+        body_layout.setContentsMargins(0, 0, 0, 0)
         body_layout.setSpacing(0)
         body_layout.addWidget(self.tab_selector_combo)
         body_layout.addWidget(self.tab_widget, stretch=1)

--- a/pandaplot/gui/components/sidebar/fit/fit_panel.py
+++ b/pandaplot/gui/components/sidebar/fit/fit_panel.py
@@ -15,14 +15,13 @@ from PySide6.QtWidgets import (
     QLineEdit,
     QMenu,
     QPushButton,
-    QScrollArea,
     QSpinBox,
     QTextEdit,
     QVBoxLayout,
     QWidget,
 )
 
-from pandaplot.gui.core.widget_extension import PWidget
+from pandaplot.gui.components.sidebar.panels.sidebar_panel import SidebarPanel
 from pandaplot.models.events import FitEvents, ChartEvents, UIEvents
 from pandaplot.models.project.items import Dataset
 from pandaplot.models.state import AppContext
@@ -30,7 +29,7 @@ from pandaplot.services.fit.fit_service import FitService
 from pandaplot.services.theme import ThemeManager
 
 
-class FitPanel(PWidget):
+class FitPanel(SidebarPanel):
     """Side panel for performing curve fitting on chart data."""
 
     fit_completed = Signal(dict)  # Emitted when fit is completed with results
@@ -64,36 +63,29 @@ class FitPanel(PWidget):
     @override
     def _init_ui(self):
         """Set up the user interface."""
-        layout = QVBoxLayout(self)
-        layout.setContentsMargins(10, 10, 10, 10)
-        
-        # Title
-        self.title_label = QLabel("Curve Fitting")
-        layout.addWidget(self.title_label)
+        self._init_panel_layout()
 
-        # Scroll area for content
-        scroll = QScrollArea()
-        scroll.setWidgetResizable(True)
-        scroll.setVerticalScrollBarPolicy(Qt.ScrollBarPolicy.ScrollBarAsNeeded)
-        scroll.setHorizontalScrollBarPolicy(Qt.ScrollBarPolicy.ScrollBarAsNeeded)
-        
+        # Title
+        self._set_title("Curve Fitting")
+
         content_widget = QWidget()
         content_layout = QVBoxLayout(content_widget)
-        
+        content_layout.setContentsMargins(4, 4, 4, 4)
+        content_layout.setSpacing(6)
+
         # Data source section
         self._create_data_source_section(content_layout)
-        
+
         # Fit configuration section
         self._create_fit_config_section(content_layout)
-        
+
         # Results section
         self._create_results_section(content_layout)
-        
+
         # Action buttons
         self._create_action_buttons(content_layout)
-        
-        scroll.setWidget(content_widget)
-        layout.addWidget(scroll)
+
+        self._set_content(content_widget, scrollable=True)
 
     @override
     def _apply_theme(self):
@@ -131,17 +123,8 @@ class FitPanel(PWidget):
             }}
         """)
 
-        # Title label with improved styling
-        self.title_label.setStyleSheet(f"""
-            QLabel {{
-                font-size: 14px;
-                font-weight: bold;
-                color: {base_fg};
-                padding: 5px;
-                background-color: {card_border};
-                border-radius: 3px;
-            }}
-        """)
+        # Title label with shared styling
+        self.title_label.setStyleSheet(self.title_stylesheet(base_fg, card_border))
 
         # Main action buttons
         self._apply_button_styling()

--- a/pandaplot/gui/components/sidebar/fit/fit_panel.py
+++ b/pandaplot/gui/components/sidebar/fit/fit_panel.py
@@ -4,7 +4,7 @@ from dataclasses import replace
 from typing import Optional, override
 
 import pandas as pd
-from PySide6.QtCore import Qt, Signal
+from PySide6.QtCore import Signal
 from PySide6.QtWidgets import (
     QCheckBox,
     QComboBox,

--- a/pandaplot/gui/components/sidebar/fit/fit_panel.py
+++ b/pandaplot/gui/components/sidebar/fit/fit_panel.py
@@ -66,7 +66,7 @@ class FitPanel(SidebarPanel):
         self._init_panel_layout()
 
         # Title
-        self._set_title("Curve Fitting")
+        self._set_title("📐 Curve Fitting")
 
         content_widget = QWidget()
         content_layout = QVBoxLayout(content_widget)

--- a/pandaplot/gui/components/sidebar/panels/sidebar_panel.py
+++ b/pandaplot/gui/components/sidebar/panels/sidebar_panel.py
@@ -1,0 +1,65 @@
+"""Shared base class for sidebar panels: a pinned title followed by a
+content area that is either scrollable or added directly.
+"""
+from typing import Optional
+
+from PySide6.QtCore import Qt
+from PySide6.QtWidgets import QLabel, QScrollArea, QVBoxLayout, QWidget
+
+from pandaplot.gui.core.widget_extension import PWidget
+from pandaplot.models.state.app_context import AppContext
+
+
+class SidebarPanel(PWidget):
+    """Base class for sidebar panels.
+
+    Subclasses call, in order, from their `_init_ui()`:
+    1. `self._init_panel_layout()`
+    2. `self._set_title("...")`
+    3. build their content widget as today
+    4. `self._set_content(content_widget, scrollable=...)`
+    """
+
+    def __init__(self, app_context: AppContext, parent: Optional[QWidget] = None, **kwargs):
+        super().__init__(app_context=app_context, parent=parent, **kwargs)
+        self.main_layout: Optional[QVBoxLayout] = None
+        self.title_label: Optional[QLabel] = None
+
+    def _init_panel_layout(self) -> QVBoxLayout:
+        """Create `self.main_layout` with the shared panel margins/spacing."""
+        self.main_layout = QVBoxLayout(self)
+        self.main_layout.setContentsMargins(8, 8, 8, 8)
+        self.main_layout.setSpacing(8)
+        return self.main_layout
+
+    def _set_title(self, text: str) -> QLabel:
+        """Create `self.title_label` and pin it at the top of `main_layout`."""
+        assert self.main_layout is not None, "_init_panel_layout must run first"
+        self.title_label = QLabel(text)
+        self.main_layout.addWidget(self.title_label)
+        return self.title_label
+
+    def _set_content(self, widget: QWidget, scrollable: bool = True) -> None:
+        """Add `widget` to `main_layout`, after the title.
+
+        If `scrollable`, wrap `widget` in a frameless, resizable QScrollArea
+        first, so only the content scrolls and the title stays pinned.
+        """
+        assert self.main_layout is not None, "_init_panel_layout must run first"
+        if scrollable:
+            scroll_area = QScrollArea()
+            scroll_area.setWidgetResizable(True)
+            scroll_area.setHorizontalScrollBarPolicy(Qt.ScrollBarPolicy.ScrollBarAsNeeded)
+            scroll_area.setVerticalScrollBarPolicy(Qt.ScrollBarPolicy.ScrollBarAsNeeded)
+            scroll_area.setWidget(widget)
+            self.main_layout.addWidget(scroll_area)
+        else:
+            self.main_layout.addWidget(widget)
+
+    @staticmethod
+    def title_stylesheet(base_fg: str, card_border: str) -> str:
+        """Shared title-label stylesheet, parameterized by theme colors."""
+        return (
+            f"font-size: 14px; font-weight: bold; color: {base_fg}; "
+            f"padding: 5px; background-color: {card_border}; border-radius: 3px;"
+        )

--- a/pandaplot/gui/components/sidebar/preprocessing/preprocessing_panel.py
+++ b/pandaplot/gui/components/sidebar/preprocessing/preprocessing_panel.py
@@ -5,7 +5,6 @@ scaling) applied to dataset columns before plotting or analysis.
 
 from typing import Any, Dict, Optional, override
 
-from PySide6.QtCore import Qt
 from PySide6.QtWidgets import (
     QAbstractItemView,
     QCheckBox,
@@ -17,7 +16,6 @@ from PySide6.QtWidgets import (
     QLabel,
     QListWidget,
     QPushButton,
-    QScrollArea,
     QTextEdit,
     QVBoxLayout,
     QWidget,
@@ -28,14 +26,14 @@ from pandaplot.analysis.preprocessing_types import PREPROCESSING_METHODS, list_m
 from pandaplot.commands.project.dataset.preprocess_column_command import (
     PreprocessColumnCommand,
 )
-from pandaplot.gui.core.widget_extension import PWidget
+from pandaplot.gui.components.sidebar.panels.sidebar_panel import SidebarPanel
 from pandaplot.models.events import DatasetEvents, DatasetOperationEvents, UIEvents
 from pandaplot.models.project.items import Dataset
 from pandaplot.models.state.app_context import AppContext
 from pandaplot.services.theme.theme_manager import ThemeManager
 
 
-class PreprocessingPanel(PWidget):
+class PreprocessingPanel(SidebarPanel):
     """
     Side panel for applying preprocessing transformations to dataset columns.
     """
@@ -52,17 +50,9 @@ class PreprocessingPanel(PWidget):
     @override
     def _init_ui(self):
         """Build the panel layout."""
-        main_layout = QVBoxLayout(self)
-        main_layout.setContentsMargins(8, 8, 8, 8)
-        main_layout.setSpacing(8)
+        self._init_panel_layout()
 
-        self.title_label = QLabel("⚖️ Preprocessing")
-        main_layout.addWidget(self.title_label)
-
-        scroll_area = QScrollArea()
-        scroll_area.setWidgetResizable(True)
-        scroll_area.setHorizontalScrollBarPolicy(Qt.ScrollBarPolicy.ScrollBarAsNeeded)
-        scroll_area.setVerticalScrollBarPolicy(Qt.ScrollBarPolicy.ScrollBarAsNeeded)
+        self._set_title("⚖️ Preprocessing")
 
         content_widget = QWidget()
         content_layout = QVBoxLayout(content_widget)
@@ -78,8 +68,7 @@ class PreprocessingPanel(PWidget):
 
         content_layout.addStretch()
 
-        scroll_area.setWidget(content_widget)
-        main_layout.addWidget(scroll_area)
+        self._set_content(content_widget, scrollable=True)
 
     def create_method_section(self, layout):
         """Create the transformation selector and its description."""
@@ -433,16 +422,7 @@ class PreprocessingPanel(PWidget):
             }}
         """)
 
-        self.title_label.setStyleSheet(f"""
-            QLabel {{
-                font-size: 14px;
-                font-weight: bold;
-                color: {base_fg};
-                padding: 5px;
-                background-color: {card_border};
-                border-radius: 3px;
-            }}
-        """)
+        self.title_label.setStyleSheet(self.title_stylesheet(base_fg, card_border))
 
         for label in (self.description_label, self.naming_hint):
             label.setStyleSheet(f"QLabel {{ color: {secondary_fg}; background-color: transparent; }}")

--- a/pandaplot/gui/components/sidebar/project/project_view_panel.py
+++ b/pandaplot/gui/components/sidebar/project/project_view_panel.py
@@ -11,18 +11,18 @@ from PySide6.QtWidgets import (
 )
 
 from pandaplot.commands.project.item import RenameItemCommand
+from pandaplot.gui.components.sidebar.panels.sidebar_panel import SidebarPanel
 from pandaplot.gui.components.sidebar.project.item_name_delegate import ItemNameDelegate
 from pandaplot.gui.components.sidebar.project.project_command_manager import ProjectPanelCommandManager
 from pandaplot.gui.components.sidebar.project.project_context_manager import ProjectViewPanelContextManager
 from pandaplot.gui.components.sidebar.project.project_tree import ProjectTreeWidget
 from pandaplot.gui.components.sidebar.project.project_tree_manager import ProjectTreeManager
-from pandaplot.gui.core.widget_extension import PWidget
 from pandaplot.models.events.event_types import ProjectEvents
 from pandaplot.models.state.app_context import AppContext
 from pandaplot.services.theme.theme_manager import ThemeManager
 
 
-class ProjectViewPanel(PWidget):
+class ProjectViewPanel(SidebarPanel):
     """
     UI component that displays project information and listens to app state changes.
     This follows the MVC pattern by listening to events from the app state.
@@ -61,17 +61,14 @@ class ProjectViewPanel(PWidget):
     def _init_ui(self):
         """Create the treeview widget."""
         # Main layout
-        layout = QVBoxLayout(self)
-        layout.setContentsMargins(8, 8, 8, 8)
-        layout.setSpacing(8)
+        self._init_panel_layout()
 
-        # Panel title  
-        self.title_label = QLabel("📁 Project Explorer")
-        layout.addWidget(self.title_label)
+        # Panel title
+        self._set_title("📁 Project Explorer")
 
         # Create project title display
         self.title_frame = QGroupBox("Project Info")
-        layout.addWidget(self.title_frame)
+        self.main_layout.addWidget(self.title_frame)
 
         title_layout = QVBoxLayout(self.title_frame)
         title_layout.setContentsMargins(4, 4, 4, 4)
@@ -110,7 +107,7 @@ class ProjectViewPanel(PWidget):
         self.tree.setDragDropMode(QAbstractItemView.DragDropMode.InternalMove)
         self.tree.setDefaultDropAction(Qt.DropAction.MoveAction)
 
-        layout.addWidget(self.tree)
+        self.main_layout.addWidget(self.tree)
 
         self.project_tree_manager = ProjectTreeManager(
             self.app_context, self.tree, self.on_item_name_changed)
@@ -262,16 +259,7 @@ class ProjectViewPanel(PWidget):
         """)
         
         # Style panel title (like other panels)
-        self.title_label.setStyleSheet(f"""
-            QLabel {{
-                font-size: 14px;
-                font-weight: bold;
-                color: {base_fg};
-                padding: 5px;
-                background-color: {card_border};
-                border-radius: 3px;
-            }}
-        """)
+        self.title_label.setStyleSheet(self.title_stylesheet(base_fg, card_border))
         
         # Apply theme to project title and file labels
         self.project_title_label.setStyleSheet(f"""

--- a/pandaplot/gui/components/sidebar/signal/signal_panel.py
+++ b/pandaplot/gui/components/sidebar/signal/signal_panel.py
@@ -12,20 +12,19 @@ from PySide6.QtWidgets import (
     QSpinBox,
     QPushButton,
     QTextEdit,
-    QScrollArea,
     QHBoxLayout,
 )
 
 from pandaplot.analysis import SIGNAL_ANALYSES, SignalAnalysisResult
 from pandaplot.commands.project.dataset.signal_analysis_command import SignalAnalysisCommand
-from pandaplot.gui.core.widget_extension import PWidget
+from pandaplot.gui.components.sidebar.panels.sidebar_panel import SidebarPanel
 from pandaplot.models.state.app_context import AppContext
 from pandaplot.models.project.items import Dataset
 from pandaplot.models.events import DatasetOperationEvents, UIEvents
 from pandaplot.services.theme.theme_manager import ThemeManager
 
 
-class SignalPanel(PWidget):
+class SignalPanel(SidebarPanel):
     """Sidebar panel for signal analysis."""
 
     def __init__(
@@ -44,25 +43,14 @@ class SignalPanel(PWidget):
 
     @override
     def _init_ui(self):
-        main_layout = QVBoxLayout(self)
-        main_layout.setContentsMargins(8, 8, 8, 8)
+        self._init_panel_layout()
 
-        scroll_area = QScrollArea()
-        scroll_area.setWidgetResizable(True)
-        scroll_area.setHorizontalScrollBarPolicy(
-            Qt.ScrollBarPolicy.ScrollBarAsNeeded
-        )
-        scroll_area.setVerticalScrollBarPolicy(
-            Qt.ScrollBarPolicy.ScrollBarAsNeeded
-        )
+        self._set_title("📡 Signal Analysis")
 
         content_widget = QWidget()
         layout = QVBoxLayout(content_widget)
         layout.setContentsMargins(4, 4, 4, 4)
         layout.setSpacing(8)
-
-        self.title_label = QLabel("📡 Signal Analysis")
-        layout.addWidget(self.title_label)
 
         # Analysis selector
         group = QGroupBox("Analysis")
@@ -143,8 +131,7 @@ class SignalPanel(PWidget):
 
         layout.addStretch()
 
-        scroll_area.setWidget(content_widget)
-        main_layout.addWidget(scroll_area)
+        self._set_content(content_widget, scrollable=True)
         self._on_analysis_changed()
 
     def _on_analysis_changed(self):
@@ -520,16 +507,7 @@ class SignalPanel(PWidget):
             }}
         """)
 
-        self.title_label.setStyleSheet(f"""
-            QLabel {{
-                font-size: 14px;
-                font-weight: bold;
-                color: {base_fg};
-                padding: 5px;
-                background-color: {card_border};
-                border-radius: 3px;
-            }}
-        """)
+        self.title_label.setStyleSheet(self.title_stylesheet(base_fg, card_border))
 
         self.run_btn.setStyleSheet("""
             QPushButton {

--- a/pandaplot/gui/components/sidebar/signal/signal_panel.py
+++ b/pandaplot/gui/components/sidebar/signal/signal_panel.py
@@ -1,6 +1,5 @@
 from typing import Optional, override, List
 
-from PySide6.QtCore import Qt
 from PySide6.QtWidgets import (
     QComboBox,
     QGroupBox,

--- a/pandaplot/gui/components/sidebar/statistics/descriptive_panel.py
+++ b/pandaplot/gui/components/sidebar/statistics/descriptive_panel.py
@@ -6,7 +6,6 @@ previewing a report, and adding the results to the project as data.
 
 from typing import List, Optional, override
 
-from PySide6.QtCore import Qt
 from PySide6.QtWidgets import (
     QAbstractItemView,
     QCheckBox,
@@ -15,7 +14,6 @@ from PySide6.QtWidgets import (
     QLabel,
     QListWidget,
     QPushButton,
-    QScrollArea,
     QSpinBox,
     QTextEdit,
     QVBoxLayout,
@@ -24,14 +22,14 @@ from PySide6.QtWidgets import (
 
 from pandaplot.analysis import DescriptiveStatsResult
 from pandaplot.commands.project.dataset.descriptive_stats_command import DescriptiveStatsCommand
-from pandaplot.gui.core.widget_extension import PWidget
+from pandaplot.gui.components.sidebar.panels.sidebar_panel import SidebarPanel
 from pandaplot.models.events import DatasetEvents, DatasetOperationEvents, UIEvents
 from pandaplot.models.project.items import Dataset
 from pandaplot.models.state.app_context import AppContext
 from pandaplot.services.theme.theme_manager import ThemeManager
 
 
-class DescriptiveStatsPanel(PWidget):
+class DescriptiveStatsPanel(SidebarPanel):
     """Side panel for computing descriptive statistics on dataset columns."""
 
     def __init__(self, app_context: AppContext, parent: Optional[QWidget] = None):
@@ -48,17 +46,9 @@ class DescriptiveStatsPanel(PWidget):
 
     @override
     def _init_ui(self):
-        main_layout = QVBoxLayout(self)
-        main_layout.setContentsMargins(8, 8, 8, 8)
-        main_layout.setSpacing(8)
+        self._init_panel_layout()
 
-        self.title_label = QLabel("📋 Descriptive Statistics")
-        main_layout.addWidget(self.title_label)
-
-        scroll_area = QScrollArea()
-        scroll_area.setWidgetResizable(True)
-        scroll_area.setHorizontalScrollBarPolicy(Qt.ScrollBarPolicy.ScrollBarAsNeeded)
-        scroll_area.setVerticalScrollBarPolicy(Qt.ScrollBarPolicy.ScrollBarAsNeeded)
+        self._set_title("📋 Descriptive Statistics")
 
         content_widget = QWidget()
         content_layout = QVBoxLayout(content_widget)
@@ -71,8 +61,7 @@ class DescriptiveStatsPanel(PWidget):
         self._create_action_buttons(content_layout)
 
         content_layout.addStretch()
-        scroll_area.setWidget(content_widget)
-        main_layout.addWidget(scroll_area)
+        self._set_content(content_widget, scrollable=True)
 
     def _create_input_section(self, layout):
         group = QGroupBox("Columns")
@@ -326,16 +315,7 @@ class DescriptiveStatsPanel(PWidget):
             }}
         """)
 
-        self.title_label.setStyleSheet(f"""
-            QLabel {{
-                font-size: 14px;
-                font-weight: bold;
-                color: {base_fg};
-                padding: 5px;
-                background-color: {card_border};
-                border-radius: 3px;
-            }}
-        """)
+        self.title_label.setStyleSheet(self.title_stylesheet(base_fg, card_border))
 
         self.run_btn.setStyleSheet("""
             QPushButton {

--- a/pandaplot/gui/components/sidebar/statistics/statistics_panel.py
+++ b/pandaplot/gui/components/sidebar/statistics/statistics_panel.py
@@ -5,7 +5,6 @@ hypothesis tests on dataset columns and adding the results to the project as dat
 
 from typing import List, Optional, override
 
-from PySide6.QtCore import Qt
 from PySide6.QtWidgets import (
     QAbstractItemView,
     QCheckBox,
@@ -17,7 +16,6 @@ from PySide6.QtWidgets import (
     QLabel,
     QListWidget,
     QPushButton,
-    QScrollArea,
     QTextEdit,
     QVBoxLayout,
     QWidget,
@@ -25,15 +23,15 @@ from PySide6.QtWidgets import (
 
 from pandaplot.analysis import STAT_TESTS, InputMode, StatTestResult, StatTestType
 from pandaplot.commands.project.dataset.statistical_test_command import StatisticalTestCommand
+from pandaplot.gui.components.sidebar.panels.sidebar_panel import SidebarPanel
 from pandaplot.gui.components.sidebar.statistics.test_info_dialog import TestInfoDialog
-from pandaplot.gui.core.widget_extension import PWidget
 from pandaplot.models.events import DatasetEvents, DatasetOperationEvents, UIEvents
 from pandaplot.models.project.items import Dataset
 from pandaplot.models.state.app_context import AppContext
 from pandaplot.services.theme.theme_manager import ThemeManager
 
 
-class StatisticsPanel(PWidget):
+class StatisticsPanel(SidebarPanel):
     """Side panel for guided statistical testing on dataset columns."""
 
     def __init__(self, app_context: AppContext, parent: Optional[QWidget] = None):
@@ -50,17 +48,9 @@ class StatisticsPanel(PWidget):
 
     @override
     def _init_ui(self):
-        main_layout = QVBoxLayout(self)
-        main_layout.setContentsMargins(8, 8, 8, 8)
-        main_layout.setSpacing(8)
+        self._init_panel_layout()
 
-        self.title_label = QLabel("🧪 Statistical Tests")
-        main_layout.addWidget(self.title_label)
-
-        scroll_area = QScrollArea()
-        scroll_area.setWidgetResizable(True)
-        scroll_area.setHorizontalScrollBarPolicy(Qt.ScrollBarPolicy.ScrollBarAsNeeded)
-        scroll_area.setVerticalScrollBarPolicy(Qt.ScrollBarPolicy.ScrollBarAsNeeded)
+        self._set_title("🧪 Statistical Tests")
 
         content_widget = QWidget()
         content_layout = QVBoxLayout(content_widget)
@@ -74,8 +64,7 @@ class StatisticsPanel(PWidget):
         self._create_action_buttons(content_layout)
 
         content_layout.addStretch()
-        scroll_area.setWidget(content_widget)
-        main_layout.addWidget(scroll_area)
+        self._set_content(content_widget, scrollable=True)
 
         # Populate for the initially selected test.
         self._on_test_type_changed()
@@ -464,16 +453,7 @@ class StatisticsPanel(PWidget):
             }}
         """)
 
-        self.title_label.setStyleSheet(f"""
-            QLabel {{
-                font-size: 14px;
-                font-weight: bold;
-                color: {base_fg};
-                padding: 5px;
-                background-color: {card_border};
-                border-radius: 3px;
-            }}
-        """)
+        self.title_label.setStyleSheet(self.title_stylesheet(base_fg, card_border))
 
         self.run_btn.setStyleSheet("""
             QPushButton {

--- a/pandaplot/gui/components/sidebar/transform/transform_panel.py
+++ b/pandaplot/gui/components/sidebar/transform/transform_panel.py
@@ -7,7 +7,6 @@ for applying transformations to dataset tabs.
 
 from typing import Optional, override
 
-from PySide6.QtCore import Qt
 from PySide6.QtWidgets import (
     QAbstractItemView,
     QCheckBox,
@@ -19,20 +18,19 @@ from PySide6.QtWidgets import (
     QLineEdit,
     QListWidget,
     QPushButton,
-    QScrollArea,
     QTextEdit,
     QVBoxLayout,
     QWidget,
 )
 
+from pandaplot.gui.components.sidebar.panels.sidebar_panel import SidebarPanel
 from pandaplot.gui.components.sidebar.transform.transform_controller import TransformController
-from pandaplot.gui.core.widget_extension import PWidget
 from pandaplot.models.events import DatasetOperationEvents, UIEvents
 from pandaplot.models.state.app_context import AppContext
 from pandaplot.services.theme.theme_manager import ThemeManager
 
 
-class TransformPanel(PWidget):
+class TransformPanel(SidebarPanel):
     """
     Transform panel for data transformations, adapted from transform_tab.py.
     Designed for sidebar integration with conditional visibility.
@@ -63,51 +61,40 @@ class TransformPanel(PWidget):
     def _init_ui(self):
         """Create the UI layout optimized for sidebar width constraints."""
         # Main layout with scroll area for long content
-        main_layout = QVBoxLayout(self)
-        main_layout.setContentsMargins(8, 8, 8, 8)
-        main_layout.setSpacing(8)
-        
+        self._init_panel_layout()
+
         # Panel title
-        self.title_label = QLabel("🔧 Transform Operations")
-        # Remove hardcoded styling - will be applied in _apply_theme
-        main_layout.addWidget(self.title_label)
-        
-        # Create scroll area for panel content
-        scroll_area = QScrollArea()
-        scroll_area.setWidgetResizable(True)
-        scroll_area.setHorizontalScrollBarPolicy(Qt.ScrollBarPolicy.ScrollBarAsNeeded)
-        scroll_area.setVerticalScrollBarPolicy(Qt.ScrollBarPolicy.ScrollBarAsNeeded)
-        
+        self._set_title("🔧 Transform Operations")
+
         # Content widget
         content_widget = QWidget()
         content_layout = QVBoxLayout(content_widget)
         content_layout.setContentsMargins(4, 4, 4, 4)
         content_layout.setSpacing(6)
-        
+
         # Header section (dataset info)
         self.create_header_section(content_layout)
-        
+
         # Transform type selection
         self.create_transform_type_section(content_layout)
-        
+
         # Column selection section
         self.create_column_selection_section(content_layout)
-        
+
         # Function definition area
         self.create_function_section(content_layout)
-        
+
         # Preview section
         self.create_preview_section(content_layout)
-        
+
         # Action buttons
         self.create_action_buttons(content_layout)
-        
+
         # Add stretch to push content to top
         content_layout.addStretch()
-        
+
         # Set content widget in scroll area
-        scroll_area.setWidget(content_widget)
-        main_layout.addWidget(scroll_area)
+        self._set_content(content_widget, scrollable=True)
     
     @override
     def _apply_theme(self):
@@ -148,16 +135,7 @@ class TransformPanel(PWidget):
         """)
         
         # Style panel title
-        self.title_label.setStyleSheet(f"""
-            QLabel {{
-                font-size: 14px;
-                font-weight: bold;
-                color: {base_fg};
-                padding: 5px;
-                background-color: {card_border};
-                border-radius: 3px;
-            }}
-        """)
+        self.title_label.setStyleSheet(self.title_stylesheet(base_fg, card_border))
         
         # Style dataset labels in header
         self.dataset_label.setStyleSheet(f"""


### PR DESCRIPTION
## Summary

Fixes #153 and #155 by introducing a shared `SidebarPanel` base class (`pandaplot/gui/components/sidebar/panels/sidebar_panel.py`) and migrating all 9 sidebar panels onto it, so every panel has an identically-pinned title and identically-margined, correctly-scrolling content area.

- Adds `SidebarPanel(PWidget)` with `_init_panel_layout()`, `_set_title()`, `_set_content(widget, scrollable=...)`, and a shared `title_stylesheet()` helper — de-duplicating what was previously hand-rolled, drifting boilerplate in 9 separate files.
- Migrates `AnalysisPanel`, `StatisticsPanel`, `DescriptiveStatsPanel`, `TransformPanel`, `PreprocessingPanel`, `SignalPanel`, `FitPanel`, `ChartPropertiesPanel`, and `ProjectViewPanel` onto the new base class.
- **#153**: `SignalPanel`'s title was added inside its scrollable content instead of pinned above it — fixed by construction now that the base class enforces title-before-scroll-area ordering.
- **#155**: `ChartPropertiesPanel` (0px margins) and `FitPanel` (10px margins) were outliers vs. the shared 8px norm used by the other panels — both now use the same `(8,8,8,8)` margins via the base class.
- Bundled: `FitPanel`'s title was missing an emoji matching its icon-bar button (now "📐 Curve Fitting"), and `ChartPropertiesPanel`'s title emoji was changed from 📊 (duplicating `AnalysisPanel`'s) to 📈 (matching its own icon-bar button).
- Documents the new base class in `docs/arch/05-gui-layer.md`.

## Test plan

- [x] Full suite: `pytest tests/ -q` — 930 passed
- [x] Every task in the implementation plan reviewed independently (spec compliance + code quality), with fixes applied and re-reviewed where needed
- [x] Final whole-branch review (opus) verified uniformity empirically across all 9 panels — identical margins/spacing/title-pinning/stylesheet, correct non-scrollable divergence for `ChartPropertiesPanel`/`ProjectViewPanel`, no other code depends on the old title strings
- [x] Visually verified all 9 panels in the running app (screenshots) — titles pinned, consistent margins, correct icons

🤖 Generated with [Claude Code](https://claude.com/claude-code)