### PR TITLE
Unify button colors/styling across panels via ThemeManager

### DIFF
--- a/pandaplot/gui/components/sidebar/analysis/analysis_panel.py
+++ b/pandaplot/gui/components/sidebar/analysis/analysis_panel.py
@@ -123,21 +123,6 @@ class AnalysisPanel(SidebarPanel):
         # Style title label
         self.title_label.setStyleSheet(self.title_stylesheet(base_fg, card_border))
         
-        # Style preview button
-        self.preview_btn.setStyleSheet("""
-            QPushButton {
-                background-color: #3498db;
-                color: white;
-                border: none;
-                border-radius: 4px;
-                padding: 8px 16px;
-                font-weight: bold;
-            }
-            QPushButton:hover {
-                background-color: #2980b9;
-            }
-        """)
-        
         # Style apply button
         self.apply_btn.setStyleSheet(f"""
             QPushButton {{
@@ -272,6 +257,7 @@ class AnalysisPanel(SidebarPanel):
         group_layout = QVBoxLayout()
         
         self.preview_btn = QPushButton("🔍 Preview Analysis")
+        self.preview_btn.setProperty("primary", True)
         self.preview_btn.clicked.connect(self.preview_analysis)
         
         self.preview_text = QTextEdit()

--- a/pandaplot/gui/components/sidebar/signal/signal_panel.py
+++ b/pandaplot/gui/components/sidebar/signal/signal_panel.py
@@ -102,6 +102,7 @@ class SignalPanel(SidebarPanel):
         results_layout = QVBoxLayout()
 
         self.run_btn = QPushButton("▶ Run Analysis")
+        self.run_btn.setProperty("primary", True)
         self.run_btn.clicked.connect(self.run_analysis)
 
         results_layout.addWidget(self.run_btn)
@@ -507,21 +508,6 @@ class SignalPanel(SidebarPanel):
         """)
 
         self.title_label.setStyleSheet(self.title_stylesheet(base_fg, card_border))
-
-        self.run_btn.setStyleSheet("""
-            QPushButton {
-                background-color: #3498db;
-                color: white;
-                border: none;
-                border-radius: 4px;
-                padding: 8px 16px;
-                font-weight: bold;
-            }
-
-            QPushButton:hover {
-                background-color: #2980b9;
-            }
-        """)
 
         self.add_btn.setStyleSheet(f"""
             QPushButton {{

--- a/pandaplot/gui/components/sidebar/statistics/descriptive_panel.py
+++ b/pandaplot/gui/components/sidebar/statistics/descriptive_panel.py
@@ -109,6 +109,7 @@ class DescriptiveStatsPanel(SidebarPanel):
         group_layout = QVBoxLayout()
 
         self.run_btn = QPushButton("▶ Compute")
+        self.run_btn.setProperty("primary", True)
         self.run_btn.clicked.connect(self.compute)
         group_layout.addWidget(self.run_btn)
 
@@ -316,18 +317,6 @@ class DescriptiveStatsPanel(SidebarPanel):
         """)
 
         self.title_label.setStyleSheet(self.title_stylesheet(base_fg, card_border))
-
-        self.run_btn.setStyleSheet("""
-            QPushButton {
-                background-color: #3498db;
-                color: white;
-                border: none;
-                border-radius: 4px;
-                padding: 8px 16px;
-                font-weight: bold;
-            }
-            QPushButton:hover { background-color: #2980b9; }
-        """)
 
         self.add_btn.setStyleSheet(f"""
             QPushButton {{

--- a/pandaplot/gui/components/sidebar/statistics/statistics_panel.py
+++ b/pandaplot/gui/components/sidebar/statistics/statistics_panel.py
@@ -119,6 +119,7 @@ class StatisticsPanel(SidebarPanel):
         group_layout = QVBoxLayout()
 
         self.run_btn = QPushButton("▶ Run Test")
+        self.run_btn.setProperty("primary", True)
         self.run_btn.clicked.connect(self.run_test)
         group_layout.addWidget(self.run_btn)
 
@@ -454,18 +455,6 @@ class StatisticsPanel(SidebarPanel):
         """)
 
         self.title_label.setStyleSheet(self.title_stylesheet(base_fg, card_border))
-
-        self.run_btn.setStyleSheet("""
-            QPushButton {
-                background-color: #3498db;
-                color: white;
-                border: none;
-                border-radius: 4px;
-                padding: 8px 16px;
-                font-weight: bold;
-            }
-            QPushButton:hover { background-color: #2980b9; }
-        """)
 
         self.info_btn.setStyleSheet(f"""
             QPushButton {{

--- a/pandaplot/gui/components/sidebar/transform/transform_panel.py
+++ b/pandaplot/gui/components/sidebar/transform/transform_panel.py
@@ -107,9 +107,7 @@ class TransformPanel(SidebarPanel):
         card_border = palette.get("card_border", "#dee2e6")
         base_fg = palette.get("base_fg", "#333333")
         secondary_fg = palette.get("secondary_fg", "#666666")
-        accent = palette.get("accent", "#4CAF50")
-        card_hover = palette.get("card_hover", "#e5f3ff")
-        
+
         # Apply theme to main widget (like project view panel)
         self.setStyleSheet(f"""
             TransformPanel {{
@@ -166,39 +164,6 @@ class TransformPanel(SidebarPanel):
             }}
         """)
         
-        # Style action buttons
-        self.apply_btn.setStyleSheet(f"""
-            QPushButton {{
-                background-color: {accent};
-                color: white;
-                border: none;
-                padding: 6px 12px;
-                border-radius: 4px;
-                font-weight: bold;
-            }}
-            QPushButton:hover {{
-                background-color: {card_hover};
-                color: {base_fg};
-            }}
-            QPushButton:disabled {{
-                background-color: {secondary_fg};
-                color: #999999;
-            }}
-        """)
-        
-        self.clear_btn.setStyleSheet("""
-            QPushButton {
-                background-color: #f44336;
-                color: white;
-                border: none;
-                padding: 6px 12px;
-                border-radius: 4px;
-            }
-            QPushButton:hover {
-                background-color: #da190b;
-            }
-        """)
-
     def create_header_section(self, layout):
         """Create header section showing current dataset info."""
         header_group = QGroupBox("Active Dataset")
@@ -325,10 +290,10 @@ class TransformPanel(SidebarPanel):
         button_layout = QHBoxLayout()
         
         self.apply_btn = QPushButton("Apply")
-        # Remove hardcoded styling - will be applied in _apply_theme
-        
+        self.apply_btn.setProperty("primary", True)
+
         self.clear_btn = QPushButton("Clear")
-        # Remove hardcoded styling - will be applied in _apply_theme
+        self.clear_btn.setProperty("destructive", True)
         
         button_layout.addWidget(self.apply_btn)
         button_layout.addWidget(self.clear_btn)

--- a/pandaplot/gui/components/tabs/dataset/dataset_tab.py
+++ b/pandaplot/gui/components/tabs/dataset/dataset_tab.py
@@ -58,40 +58,7 @@ class DatasetTab(PWidget):
         card_hover = palette.get("card_hover", "#e9ecef")
         card_border = palette.get("card_border", "#dee2e6")
         base_fg = palette.get("base_fg", "#000000")
-        secondary_fg = palette.get("secondary_fg", "#555555")
         accent = palette.get("accent", "#4A90E2")
-        
-        # Derive accent color variants for interaction states
-        from PySide6.QtGui import QColor
-        accent_color = QColor(accent)
-        if accent_color.isValid():
-            accent_hover = accent_color.darker(110).name()
-            accent_pressed = accent_color.darker(125).name()
-        else:
-            accent_hover = accent
-            accent_pressed = accent
-        
-        # Apply styling to action buttons
-        for btn in [self.create_chart_btn, self.export_btn]:
-            btn.setStyleSheet(f"""
-                QPushButton {{
-                    background-color: {accent};
-                    color: white;
-                    border: none;
-                    border-radius: 4px;
-                    padding: 6px 12px;
-                    font-weight: bold;
-                }}
-                QPushButton:hover {{
-                    background-color: {accent_hover};
-                }}
-                QPushButton:pressed {{
-                    background-color: {accent_pressed};
-                }}
-                QPushButton:disabled {{
-                    background-color: {secondary_fg};
-                }}
-            """)
         
         # Apply styling to table view
         self.table_view.setStyleSheet(f"""
@@ -121,41 +88,6 @@ class DatasetTab(PWidget):
                 font-weight: bold;
                 color: {base_fg};
             }}
-        """)
-        
-        # Apply styling to action buttons
-        self.create_chart_btn.setStyleSheet(f"""
-            QPushButton {{
-                background-color: {accent};
-                color: white;
-                border: none;
-                border-radius: 4px;
-                padding: 8px 16px;
-                font-weight: bold;
-            }}
-            QPushButton:hover {{
-                background-color: {accent_hover};
-            }}
-            QPushButton:pressed {{
-                background-color: {accent_pressed};
-            }}
-        """)
-        
-        self.export_btn.setStyleSheet("""
-            QPushButton {
-                background-color: #28a745;
-                color: white;
-                border: none;
-                border-radius: 4px;
-                padding: 8px 16px;
-                font-weight: bold;
-            }
-            QPushButton:hover {
-                background-color: #1e7e34;
-            }
-            QPushButton:pressed {
-                background-color: #155724;
-            }
         """)
 
     def on_dataset_column_added(self, event_data):
@@ -211,11 +143,13 @@ class DatasetTab(PWidget):
 
         # Create chart button
         self.create_chart_btn = QPushButton("📈 Create Chart from Data")
+        self.create_chart_btn.setProperty("primary", True)
         self.create_chart_btn.clicked.connect(self.create_chart_from_data)
         actions_layout.addWidget(self.create_chart_btn)
 
         # Export data button
         self.export_btn = QPushButton("💾 Export Data")
+        self.export_btn.setProperty("primary", True)
         self.export_btn.clicked.connect(self.export_data)
         actions_layout.addWidget(self.export_btn)
 

--- a/pandaplot/gui/dialogs/settings_dialog.py
+++ b/pandaplot/gui/dialogs/settings_dialog.py
@@ -329,7 +329,8 @@ class SettingsDialog(PDialog):
         accent_layout.addWidget(QLabel("Accent color:"))
         self.accent_color_btn = QPushButton()
         self.accent_color_btn.setFixedSize(70, 30)
-        self.accent_color_btn.setStyleSheet("background-color: #007bff; border-radius: 4px;")
+        initial_accent = self._config_manager.config.appearance.accent_color
+        self.accent_color_btn.setStyleSheet(f"background-color: {initial_accent}; border-radius: 4px;")
         self.accent_color_btn.clicked.connect(self.choose_accent_color)
         accent_layout.addWidget(self.accent_color_btn)
         accent_layout.addStretch()

--- a/pandaplot/services/theme/theme_manager.py
+++ b/pandaplot/services/theme/theme_manager.py
@@ -105,6 +105,14 @@ class ThemeManager:
             pass
 
         tokens = self.get_design_tokens()
+        danger = tokens["status_danger"]
+        danger_c = QColor(danger)
+        if danger_c.isValid():
+            danger_hover = danger_c.lighter(110).name()
+            danger_pressed = danger_c.darker(115).name()
+        else:
+            danger_hover = danger
+            danger_pressed = danger
         shared_widget_rules = f"""
             QFrame[card="true"] {{
                 background-color: {tokens['surface_white']};
@@ -160,6 +168,21 @@ class ThemeManager:
             QPushButton[primary="true"]:pressed {{
                 background-color: {pressed};
                 border-color: {pressed};
+            }}
+            QPushButton[destructive="true"] {{
+                background-color: {danger};
+                border: 1px solid {danger};
+                border-radius: 4px;
+                padding: 4px 8px;
+                color: #FFFFFF;
+            }}
+            QPushButton[destructive="true"]:hover {{
+                background-color: {danger_hover};
+                border-color: {danger_hover};
+            }}
+            QPushButton[destructive="true"]:pressed {{
+                background-color: {danger_pressed};
+                border-color: {danger_pressed};
             }}
             QTabBar::tab:selected {{ color: {accent}; }}
         """ + shared_widget_rules
@@ -242,7 +265,7 @@ class ThemeManager:
                 "accent": accent, "accent_active_text": accent_active_text,
                 "accent_selected_bg": "#2E3350", "accent_disabled": accent_disabled,
                 "status_modified_dot": "#E09A1F", "status_modified_text": "#E0A94A",
-                "status_success": "#3FA46A",
+                "status_success": "#3FA46A", "status_danger": "#C24141",
                 "y2_accent": "#B27FD1", "y2_accent_bg": "#3A2E45",
                 "series_palette": ["#C24141", "#6B77E8", "#3F9BB0", "#3FA46A", "#E09A1F"],
                 "radius_swatch": 4, "radius_control": 5, "radius_card": 6, "radius_chip": 12,
@@ -257,7 +280,7 @@ class ThemeManager:
             "accent": accent, "accent_active_text": accent_active_text,
             "accent_selected_bg": "#EEF0FB", "accent_disabled": accent_disabled,
             "status_modified_dot": "#E09A1F", "status_modified_text": "#B06A00",
-            "status_success": "#3FA46A",
+            "status_success": "#3FA46A", "status_danger": "#DC3545",
             "y2_accent": "#8A4BB8", "y2_accent_bg": "#F5EEFB",
             "series_palette": ["#A01818", "#4A56C6", "#2B7A8C", "#3FA46A", "#E09A1F"],
             "radius_swatch": 4, "radius_control": 5, "radius_card": 6, "radius_chip": 12,


### PR DESCRIPTION
## Summary
- Migrates hardcoded per-widget button `setStyleSheet()` colors (analysis, statistics, descriptive, signal, transform panels, the dataset tab, and the settings dialog's accent swatch) to the shared `ThemeManager`-driven QSS.
- Primary action buttons (`Preview`/`Run`/`Compute`/`Create Chart`/`Export`/`Apply`) now use the existing `QPushButton[primary="true"]` dynamic property instead of a locally hardcoded blue/green.
- Adds a new `QPushButton[destructive="true"]` semantic rule (+ `status_danger` design token) to `ThemeManager`, and switches the red "Clear" button in the transform panel to it instead of a hardcoded `#f44336`.
- Fixes the settings dialog's accent-color swatch, which previously always started at a hardcoded `#007bff` fallback instead of the user's actual configured accent color.
- Removes now-dead/duplicate button styling code found along the way (`dataset_tab.py` had two competing style blocks for the same buttons).

All affected buttons now automatically re-theme when the user changes theme/accent instead of keeping a flat light-mode color.

Fixes #152

## Test plan
- [x] Full test suite: `pytest -q` → 930 passed
- [x] Rendered `primary`/`destructive`/plain buttons offscreen under both light and dark `ThemeManager` contexts and confirmed pixel colors match the expected accent/danger colors (see screenshots below)

Light theme:
`primary=#4a56c6 destructive=#dc3545 plain=#f5f5f5`

Dark theme:
`primary=#4a56c6 destructive=#c24141 plain=#f5f5f5`

🤖 Generated with [Claude Code](https://claude.com/claude-code)