### PR TITLE
Add adjustable axis title and tick label rotation angle

### DIFF
--- a/pandaplot/gui/components/sidebar/chart/tabs/style_tab.py
+++ b/pandaplot/gui/components/sidebar/chart/tabs/style_tab.py
@@ -694,6 +694,13 @@ class StyleTab(QWidget):
             color_label.setVisible(False)
             color_row.setVisible(False)
 
+        title_layout.addWidget(QLabel("Rotation:"), 5, 0)
+        rotation_spin = QSpinBox()
+        rotation_spin.setRange(-90, 90)
+        rotation_spin.setSuffix("°")
+        rotation_spin.setValue(90 if prefix in ("y", "y2") else 0)
+        title_layout.addWidget(rotation_spin, 5, 1)
+
         form_layout.addWidget(title_card)
 
         ticks_card = Card()
@@ -723,6 +730,12 @@ class StyleTab(QWidget):
         ticks_layout.addWidget(QLabel("Color:"), 4, 0)
         tick_color_row = ColorSwatchRow(AXES_SWATCH_PALETTE)
         ticks_layout.addWidget(tick_color_row, 4, 1)
+
+        ticks_layout.addWidget(QLabel("Rotation:"), 5, 0)
+        tick_rotation_spin = QSpinBox()
+        tick_rotation_spin.setRange(-90, 90)
+        tick_rotation_spin.setSuffix("°")
+        ticks_layout.addWidget(tick_rotation_spin, 5, 1)
 
         form_layout.addWidget(ticks_card)
 
@@ -763,11 +776,13 @@ class StyleTab(QWidget):
             "bold_check": bold_check, "italic_check": italic_check,
             "color_row": color_row, "color_label": color_label,
             "match_x_toggle": match_x_toggle,
+            "rotation_spin": rotation_spin,
             "ticks_card": ticks_card,
             "tick_font_size_spin": tick_font_size_spin,
             "tick_font_family_combo": tick_font_family_combo,
             "tick_bold_check": tick_bold_check, "tick_italic_check": tick_italic_check,
             "tick_color_row": tick_color_row,
+            "tick_rotation_spin": tick_rotation_spin,
             "colors_card": colors_card,
             "spine_color_row": spine_color_row,
             "major_tick_color_row": major_tick_color_row,
@@ -782,6 +797,7 @@ class StyleTab(QWidget):
         bold_check.toggled.connect(self._on_chart_style_field_changed)
         italic_check.toggled.connect(self._on_chart_style_field_changed)
         color_row.colorChanged.connect(self._on_chart_style_field_changed)
+        rotation_spin.valueChanged.connect(self._on_chart_style_field_changed)
         if match_x_toggle is not None:
             match_x_toggle.toggled.connect(lambda checked, p=prefix: self._on_axis_style_match_x_toggled(p, checked))
 
@@ -790,6 +806,7 @@ class StyleTab(QWidget):
         tick_bold_check.toggled.connect(self._on_chart_style_field_changed)
         tick_italic_check.toggled.connect(self._on_chart_style_field_changed)
         tick_color_row.colorChanged.connect(self._on_chart_style_field_changed)
+        tick_rotation_spin.valueChanged.connect(self._on_chart_style_field_changed)
         spine_color_row.colorChanged.connect(self._on_chart_style_field_changed)
         major_tick_color_row.colorChanged.connect(self._on_chart_style_field_changed)
         minor_tick_color_row.colorChanged.connect(self._on_chart_style_field_changed)
@@ -851,10 +868,12 @@ class StyleTab(QWidget):
         target["font_family_combo"].setCurrentValue(source["font_family_combo"].currentValue())
         target["bold_check"].setChecked(source["bold_check"].isChecked())
         target["italic_check"].setChecked(source["italic_check"].isChecked())
+        target["rotation_spin"].setValue(source["rotation_spin"].value())
         target["tick_font_size_spin"].setValue(source["tick_font_size_spin"].value())
         target["tick_font_family_combo"].setCurrentValue(source["tick_font_family_combo"].currentValue())
         target["tick_bold_check"].setChecked(source["tick_bold_check"].isChecked())
         target["tick_italic_check"].setChecked(source["tick_italic_check"].isChecked())
+        target["tick_rotation_spin"].setValue(source["tick_rotation_spin"].value())
 
         # Match-X toggles MUST be set before the color swatches they gate
         # (see AxesTab._on_copy_axis_settings for why: setChecked fires
@@ -1422,6 +1441,8 @@ class StyleTab(QWidget):
                 if axis_form["match_x_toggle"] is not None:
                     axis_form["color_label"].setVisible(not match)
                     axis_form["color_row"].setVisible(not match)
+                default_rotation = 90 if prefix in ("y", "y2") else 0
+                axis_form["rotation_spin"].setValue(chart.config.get(f"{prefix}_label_rotation", default_rotation))
 
                 axis_form["tick_font_size_spin"].setValue(chart.config.get(f"{prefix}_tick_label_font_size", 10))
                 axis_form["tick_font_family_combo"].setCurrentValue(
@@ -1429,6 +1450,7 @@ class StyleTab(QWidget):
                 axis_form["tick_bold_check"].setChecked(chart.config.get(f"{prefix}_tick_label_bold", False))
                 axis_form["tick_italic_check"].setChecked(chart.config.get(f"{prefix}_tick_label_italic", False))
                 axis_form["tick_color_row"].setCurrentColor(chart.config.get(f"{prefix}_tick_label_color", "#000000"))
+                axis_form["tick_rotation_spin"].setValue(chart.config.get(f"{prefix}_tick_label_rotation", 0))
                 match_colors = True
                 if axis_form["match_x_colors_toggle"] is not None:
                     match_colors = chart.config.get(f"{prefix}_match_x_colors", True)
@@ -1486,11 +1508,13 @@ class StyleTab(QWidget):
             chart.config[f"{prefix}_label_color"] = axis_form["color_row"].currentColor()
             if axis_form["match_x_toggle"] is not None:
                 chart.config[f"{prefix}_match_x_label_color"] = axis_form["match_x_toggle"].isChecked()
+            chart.config[f"{prefix}_label_rotation"] = axis_form["rotation_spin"].value()
             chart.config[f"{prefix}_tick_label_font_size"] = axis_form["tick_font_size_spin"].value()
             chart.config[f"{prefix}_tick_label_font_family"] = axis_form["tick_font_family_combo"].currentValue()
             chart.config[f"{prefix}_tick_label_bold"] = axis_form["tick_bold_check"].isChecked()
             chart.config[f"{prefix}_tick_label_italic"] = axis_form["tick_italic_check"].isChecked()
             chart.config[f"{prefix}_tick_label_color"] = axis_form["tick_color_row"].currentColor()
+            chart.config[f"{prefix}_tick_label_rotation"] = axis_form["tick_rotation_spin"].value()
             chart.config[f"{prefix}_spine_color"] = axis_form["spine_color_row"].currentColor()
             chart.config[f"{prefix}_major_tick_color"] = axis_form["major_tick_color_row"].currentColor()
             chart.config[f"{prefix}_minor_tick_color"] = axis_form["minor_tick_color_row"].currentColor()
@@ -1543,11 +1567,13 @@ class StyleTab(QWidget):
                 axis_form["color_row"].setCurrentColor("#000000")
                 if axis_form["match_x_toggle"] is not None:
                     axis_form["match_x_toggle"].setChecked(True)
+                axis_form["rotation_spin"].setValue(90 if prefix in ("y", "y2") else 0)
                 axis_form["tick_font_size_spin"].setValue(10)
                 axis_form["tick_font_family_combo"].setCurrentValue("DejaVu Sans")
                 axis_form["tick_bold_check"].setChecked(False)
                 axis_form["tick_italic_check"].setChecked(False)
                 axis_form["tick_color_row"].setCurrentColor("#000000")
+                axis_form["tick_rotation_spin"].setValue(0)
                 axis_form["spine_color_row"].setCurrentColor("#000000")
                 axis_form["major_tick_color_row"].setCurrentColor("#000000")
                 axis_form["minor_tick_color_row"].setCurrentColor("#000000")
@@ -1669,11 +1695,13 @@ class StyleTab(QWidget):
             config[f"{prefix}_label_color"] = axis_form["color_row"].currentColor()
             if axis_form["match_x_toggle"] is not None:
                 config[f"{prefix}_match_x_label_color"] = axis_form["match_x_toggle"].isChecked()
+            config[f"{prefix}_label_rotation"] = axis_form["rotation_spin"].value()
             config[f"{prefix}_tick_label_font_size"] = axis_form["tick_font_size_spin"].value()
             config[f"{prefix}_tick_label_font_family"] = axis_form["tick_font_family_combo"].currentValue()
             config[f"{prefix}_tick_label_bold"] = axis_form["tick_bold_check"].isChecked()
             config[f"{prefix}_tick_label_italic"] = axis_form["tick_italic_check"].isChecked()
             config[f"{prefix}_tick_label_color"] = axis_form["tick_color_row"].currentColor()
+            config[f"{prefix}_tick_label_rotation"] = axis_form["tick_rotation_spin"].value()
             config[f"{prefix}_spine_color"] = axis_form["spine_color_row"].currentColor()
             config[f"{prefix}_major_tick_color"] = axis_form["major_tick_color_row"].currentColor()
             config[f"{prefix}_minor_tick_color"] = axis_form["minor_tick_color_row"].currentColor()

--- a/pandaplot/gui/components/tabs/chart/chart_editor.py
+++ b/pandaplot/gui/components/tabs/chart/chart_editor.py
@@ -176,12 +176,12 @@ def apply_axis_ticks(
     )
 
 
-def apply_tick_label_font(axis, font_size, font_family, bold=False, italic=False):
-    """Set font size/family/weight/style on every major and minor tick-value
-    label of a matplotlib Axis. `Axis.set_tick_params` (used by
+def apply_tick_label_font(axis, font_size, font_family, bold=False, italic=False, rotation=0):
+    """Set font size/family/weight/style/rotation on every major and minor
+    tick-value label of a matplotlib Axis. `Axis.set_tick_params` (used by
     `apply_axis_ticks` for color/direction) has no font-family/weight/style
-    knobs of its own, so those three must be set directly on each tick
-    label's Text artist instead."""
+    knobs of its own, so those three (plus rotation) must be set directly on
+    each tick label's Text artist instead."""
     fontweight = "bold" if bold else "normal"
     fontstyle = "italic" if italic else "normal"
     for label in axis.get_ticklabels() + axis.get_ticklabels(minor=True):
@@ -189,6 +189,7 @@ def apply_tick_label_font(axis, font_size, font_family, bold=False, italic=False
         label.set_fontfamily(font_family)
         label.set_fontweight(fontweight)
         label.set_fontstyle(fontstyle)
+        label.set_rotation(rotation)
 
 
 def resolve_axis_color(prefix, own_color, match_enabled, x_color):
@@ -966,12 +967,14 @@ class ChartEditorWidget(PWidget):
                 fontfamily=config.get("x_font_family", "DejaVu Sans"),
                 fontweight="bold" if config.get("x_title_bold", False) else "normal",
                 fontstyle="italic" if config.get("x_title_italic", False) else "normal",
+                rotation=config.get("x_label_rotation", 0),
             )
             self.chart_canvas.axes.set_ylabel(
                 config.get("y_label", ""), color=y_label_color,
                 fontfamily=config.get("y_font_family", "DejaVu Sans"),
                 fontweight="bold" if config.get("y_title_bold", False) else "normal",
                 fontstyle="italic" if config.get("y_title_italic", False) else "normal",
+                rotation=config.get("y_label_rotation", 90),
             )
             x_scale = config.get("x_scale", "linear")
             y_scale = config.get("y_scale", "linear")
@@ -995,6 +998,7 @@ class ChartEditorWidget(PWidget):
                     fontfamily=config.get("y2_font_family", "DejaVu Sans"),
                     fontweight="bold" if config.get("y2_title_bold", False) else "normal",
                     fontstyle="italic" if config.get("y2_title_italic", False) else "normal",
+                    rotation=config.get("y2_label_rotation", 90),
                 )
                 y2_scale = config.get("y2_scale", "linear")
                 self.chart_canvas.axes2.set_yscale(
@@ -1038,6 +1042,7 @@ class ChartEditorWidget(PWidget):
                     config.get("y2_tick_label_font_family", "DejaVu Sans"),
                     bold=config.get("y2_tick_label_bold", False),
                     italic=config.get("y2_tick_label_italic", False),
+                    rotation=config.get("y2_tick_label_rotation", 0),
                 )
 
                 if config.get("show_grid_y2", True):
@@ -1072,6 +1077,7 @@ class ChartEditorWidget(PWidget):
                 config.get("x_tick_label_font_family", "DejaVu Sans"),
                 bold=config.get("x_tick_label_bold", False),
                 italic=config.get("x_tick_label_italic", False),
+                rotation=config.get("x_tick_label_rotation", 0),
             )
             apply_axis_ticks(
                 self.chart_canvas.axes.yaxis,
@@ -1099,6 +1105,7 @@ class ChartEditorWidget(PWidget):
                 config.get("y_tick_label_font_family", "DejaVu Sans"),
                 bold=config.get("y_tick_label_bold", False),
                 italic=config.get("y_tick_label_italic", False),
+                rotation=config.get("y_tick_label_rotation", 0),
             )
 
             apply_spine_colors(

--- a/tests/gui/test_chart_editor_axis_title_font.py
+++ b/tests/gui/test_chart_editor_axis_title_font.py
@@ -42,3 +42,22 @@ def test_minor_tick_labels_also_get_the_font():
     minor_labels = [label for label in axis.get_ticklabels(minor=True) if label.get_text()]
     for label in minor_labels:
         assert label.get_fontfamily() == ["Georgia"]
+
+
+def test_rotation_defaults_to_zero():
+    axis = _make_axis()
+    apply_axis_ticks(axis, "auto", 5, 1.0, "auto", "")
+    apply_tick_label_font(axis, font_size=10, font_family="DejaVu Sans")
+    labels = [label for label in axis.get_ticklabels() if label.get_text()]
+    for label in labels:
+        assert label.get_rotation() == 0
+
+
+def test_rotation_is_applied_to_major_and_minor_tick_labels():
+    axis = _make_axis()
+    apply_axis_ticks(axis, "auto", 5, 1.0, "auto", "", minor_enabled=True)
+    apply_tick_label_font(axis, font_size=10, font_family="DejaVu Sans", rotation=45)
+    labels = [label for label in axis.get_ticklabels() + axis.get_ticklabels(minor=True) if label.get_text()]
+    assert labels, "expected at least one tick label after autoscale"
+    for label in labels:
+        assert label.get_rotation() == 45

--- a/tests/gui/test_style_tab_axis_rotation.py
+++ b/tests/gui/test_style_tab_axis_rotation.py
@@ -1,0 +1,102 @@
+"""Tests for the axis title/tick label rotation controls in StyleTab's
+per-axis appearance form (issue #101: adjustable axis and tick label
+angles)."""
+import types
+
+import pytest
+from PySide6.QtWidgets import QApplication
+
+from pandaplot.gui.components.sidebar.chart.tabs.style_tab import StyleTab
+from pandaplot.models.project.items.chart import Chart
+
+
+@pytest.fixture(scope="module", autouse=True)
+def qapp():
+    app = QApplication.instance() or QApplication([])
+    yield app
+
+
+def _make_app_context():
+    return types.SimpleNamespace(app_state=types.SimpleNamespace(current_project=None))
+
+
+def test_load_chart_style_sets_rotation_spinboxes():
+    chart = Chart(name="Test Chart")
+    chart.update_config({
+        "x_label_rotation": 30,
+        "x_tick_label_rotation": -45,
+    })
+
+    tab = StyleTab(_make_app_context())
+    tab.load_chart_style(chart)
+
+    x_form = tab.axes_style_forms["x"]
+    assert x_form["rotation_spin"].value() == 30
+    assert x_form["tick_rotation_spin"].value() == -45
+
+
+def test_rotation_spinboxes_default_when_missing_from_config():
+    """X title defaults to horizontal (0); Y/Y2 titles default to vertical
+    (90), matching matplotlib's own default orientation for those axes so
+    existing charts don't visually change just from loading this panel.
+    Tick-value rotation always defaults to horizontal (0) for every axis."""
+    chart = Chart(name="Test Chart")
+
+    tab = StyleTab(_make_app_context())
+    tab.load_chart_style(chart)
+
+    assert tab.axes_style_forms["x"]["rotation_spin"].value() == 0
+    assert tab.axes_style_forms["y"]["rotation_spin"].value() == 90
+    assert tab.axes_style_forms["y2"]["rotation_spin"].value() == 90
+    for prefix in ("x", "y", "y2"):
+        assert tab.axes_style_forms[prefix]["tick_rotation_spin"].value() == 0
+
+
+def test_apply_chart_style_to_saves_rotation_values():
+    chart = Chart(name="Test Chart")
+    tab = StyleTab(_make_app_context())
+    tab.load_chart_style(chart)
+
+    x_form = tab.axes_style_forms["x"]
+    x_form["rotation_spin"].setValue(60)
+    x_form["tick_rotation_spin"].setValue(-15)
+
+    tab.apply_chart_style_to(chart)
+
+    assert chart.config["x_label_rotation"] == 60
+    assert chart.config["x_tick_label_rotation"] == -15
+
+
+def test_copy_axis_style_copies_rotation_values():
+    chart = Chart(name="Test Chart")
+    chart.update_config({
+        "y2_label_rotation": 45,
+        "y2_tick_label_rotation": 90,
+    })
+
+    tab = StyleTab(_make_app_context())
+    tab.load_chart_style(chart)
+
+    tab._on_copy_axis_style("y2")
+
+    y_form = tab.axes_style_forms["y"]
+    assert y_form["rotation_spin"].value() == 45
+    assert y_form["tick_rotation_spin"].value() == 90
+
+
+def test_clear_chart_style_resets_rotation_to_defaults():
+    chart = Chart(name="Test Chart")
+    chart.update_config({
+        "x_label_rotation": 45, "x_tick_label_rotation": 45,
+        "y_label_rotation": 45, "y2_label_rotation": 45,
+    })
+
+    tab = StyleTab(_make_app_context())
+    tab.load_chart_style(chart)
+    tab.clear_chart_style()
+
+    assert tab.axes_style_forms["x"]["rotation_spin"].value() == 0
+    assert tab.axes_style_forms["y"]["rotation_spin"].value() == 90
+    assert tab.axes_style_forms["y2"]["rotation_spin"].value() == 90
+    for prefix in ("x", "y", "y2"):
+        assert tab.axes_style_forms[prefix]["tick_rotation_spin"].value() == 0

--- a/tests/models/test_chart_style_axes_legend_config.py
+++ b/tests/models/test_chart_style_axes_legend_config.py
@@ -620,6 +620,23 @@ def test_tick_label_style_fields_default_when_missing():
     assert chart.config.get("x_tick_label_italic", False) is False
 
 
+def test_axis_and_tick_label_rotation_default_to_zero_when_missing():
+    chart = Chart(name="Test Chart")
+    for prefix in ("x", "y", "y2"):
+        assert chart.config.get(f"{prefix}_label_rotation", 0) == 0
+        assert chart.config.get(f"{prefix}_tick_label_rotation", 0) == 0
+
+
+def test_axis_and_tick_label_rotation_round_trips_through_serialization():
+    chart = Chart(name="Test Chart")
+    chart.config["x_label_rotation"] = 45
+    chart.config["y_tick_label_rotation"] = -30
+    data = chart.to_dict()
+    restored = Chart.from_dict(data)
+    assert restored.config["x_label_rotation"] == 45
+    assert restored.config["y_tick_label_rotation"] == -30
+
+
 def test_legend_custom_placement_fields_default_when_missing():
     chart = Chart(name="Test Chart")
     assert chart.config.get("legend_custom_x", 1.02) == 1.02


### PR DESCRIPTION
## Summary
- Adds a Rotation control to the Axis title and Tick values cards in the Style tab's per-axis appearance form (X/Y/Y2), so users can rotate axis labels and tick labels for better readability.
- New config keys: `{prefix}_label_rotation` and `{prefix}_tick_label_rotation`, applied via `Axes.set_xlabel`/`set_ylabel`'s `rotation` kwarg and a new `rotation` parameter on `apply_tick_label_font()`.
- Y/Y2 title rotation defaults to 90° to match matplotlib's existing vertical-label default, so existing charts don't change appearance until a user explicitly adjusts it. Tick label rotation defaults to 0° for all axes (unchanged from current behavior).
- Rotation values are included in copy-style-to-other-Y-axis and reset-to-defaults behavior.

## Test plan
- [x] `pytest tests/gui/test_style_tab_axis_rotation.py tests/gui/test_chart_editor_axis_title_font.py tests/models/test_chart_style_axes_legend_config.py` — new/updated tests pass
- [x] Full suite: `pytest -q` — 1012 passed
- [x] `ruff check` on changed files — clean

Closes #101