### PR TITLE
Add PButton on_click/enabled, clean up button labels, fix Settings dialog Appearance tab

### DIFF
--- a/pandaplot/gui/components/common/dirty_footer.py
+++ b/pandaplot/gui/components/common/dirty_footer.py
@@ -21,13 +21,12 @@ class DirtyFooter(QWidget):
     def __init__(self, parent: QWidget | None = None):
         super().__init__(parent)
         self._status_label = QLabel("No changes", self)
-        self._revert_button = PButton("Revert", role="secondary", parent=self)
-        self._apply_button = PButton("Apply", role="primary", parent=self)
-
-        self._revert_button.setEnabled(False)
-        self._apply_button.setEnabled(False)
-        self._revert_button.clicked.connect(self.revertClicked)
-        self._apply_button.clicked.connect(self.applyClicked)
+        self._revert_button = PButton(
+            "Revert", role="secondary", on_click=self.revertClicked, enabled=False, parent=self
+        )
+        self._apply_button = PButton(
+            "Apply", role="primary", on_click=self.applyClicked, enabled=False, parent=self
+        )
 
         layout = QHBoxLayout(self)
         layout.setContentsMargins(8, 6, 8, 6)

--- a/pandaplot/gui/components/common/p_button.py
+++ b/pandaplot/gui/components/common/p_button.py
@@ -2,6 +2,12 @@
 standard), both applied as Qt dynamic properties consumed by
 ThemeManager's global QSS (see [secondary]/[destructive]/[primary]/[iconButton]
 selectors in pandaplot/services/theme/theme_manager.py).
+
+`on_click` and `enabled` let call sites fold their construction-time
+`clicked.connect(...)`/`setEnabled(...)` calls directly into the constructor
+call, instead of wiring them up afterward in a separate `_connect_signals()`
+step; `on_click` accepts a plain callable, a bound Qt Signal, or a
+`<signal>.emit` method.
 """
 from __future__ import annotations
 
@@ -16,7 +22,7 @@ _ROLES: tuple[ButtonRole, ...] = ("primary", "secondary", "destructive")
 
 class PButton(QPushButton):
     def __init__(self, text: str = "", role: ButtonRole = "secondary",
-                 icon: bool = False, on_click: Optional[Callable[[], None]] = None,
+                 icon: bool = False, on_click: Optional[Callable[..., object]] = None,
                  enabled: bool = True, parent: Optional[QWidget] = None):
         super().__init__(text, parent)
         self.setProperty("iconButton", icon)

--- a/pandaplot/gui/components/common/p_button.py
+++ b/pandaplot/gui/components/common/p_button.py
@@ -5,7 +5,7 @@ selectors in pandaplot/services/theme/theme_manager.py).
 """
 from __future__ import annotations
 
-from typing import Literal, Optional
+from typing import Callable, Literal, Optional
 
 from PySide6.QtWidgets import QPushButton, QWidget
 
@@ -16,10 +16,15 @@ _ROLES: tuple[ButtonRole, ...] = ("primary", "secondary", "destructive")
 
 class PButton(QPushButton):
     def __init__(self, text: str = "", role: ButtonRole = "secondary",
-                 icon: bool = False, parent: Optional[QWidget] = None):
+                 icon: bool = False, on_click: Optional[Callable[[], None]] = None,
+                 enabled: bool = True, parent: Optional[QWidget] = None):
         super().__init__(text, parent)
         self.setProperty("iconButton", icon)
         self.set_role(role)
+        if on_click is not None:
+            self.clicked.connect(on_click)
+        if not enabled:
+            self.setEnabled(False)
 
     def set_role(self, role: ButtonRole) -> None:
         for r in _ROLES:

--- a/pandaplot/gui/components/sidebar/analysis/analysis_panel.py
+++ b/pandaplot/gui/components/sidebar/analysis/analysis_panel.py
@@ -218,8 +218,7 @@ class AnalysisPanel(SidebarPanel):
         group = QGroupBox("Preview")
         group_layout = QVBoxLayout()
         
-        self.preview_btn = PButton("🔍 Preview Analysis", role="secondary")
-        self.preview_btn.clicked.connect(self.preview_analysis)
+        self.preview_btn = PButton("Preview", role="secondary", on_click=self.preview_analysis)
         
         self.preview_text = QTextEdit()
         self.preview_text.setMaximumHeight(120)
@@ -236,11 +235,9 @@ class AnalysisPanel(SidebarPanel):
         """Create action buttons section."""
         button_layout = QHBoxLayout()
         
-        self.apply_btn = PButton("Apply", role="primary")
-        self.apply_btn.clicked.connect(self.apply_analysis)
+        self.apply_btn = PButton("Apply", role="primary", on_click=self.apply_analysis)
 
-        self.clear_btn = PButton("🔄 Clear", role="secondary")
-        self.clear_btn.clicked.connect(self.clear_inputs)
+        self.clear_btn = PButton("Clear", role="secondary", on_click=self.clear_inputs)
         
         button_layout.addWidget(self.apply_btn)
         button_layout.addWidget(self.clear_btn)

--- a/pandaplot/gui/components/sidebar/chart/tabs/axes_tab.py
+++ b/pandaplot/gui/components/sidebar/chart/tabs/axes_tab.py
@@ -200,8 +200,10 @@ class AxesTab(QWidget):
 
         copy_button = None
         if prefix in ("y", "y2"):
-            copy_button = PButton("Copy settings to Y axis", role="secondary")
-            copy_button.clicked.connect(lambda _checked=False, p=prefix: self._on_copy_axis_settings(p))
+            copy_button = PButton(
+                "Copy settings to Y axis", role="secondary",
+                on_click=lambda _checked=False, p=prefix: self._on_copy_axis_settings(p)
+            )
             form_layout.addWidget(copy_button)
 
         self.axes_forms[prefix] = {

--- a/pandaplot/gui/components/sidebar/chart/tabs/data_tab.py
+++ b/pandaplot/gui/components/sidebar/chart/tabs/data_tab.py
@@ -112,9 +112,10 @@ class DataTab(QWidget):
         self._series_section_header = SectionHeader("Series")
         header_row.addWidget(self._series_section_header)
         header_row.addStretch(1)
-        self.add_series_button = PButton("+ Add series", role="secondary")
+        self.add_series_button = PButton(
+            "+ Add series", role="secondary", on_click=self._add_series
+        )
         self.add_series_button.setCursor(Qt.CursorShape.PointingHandCursor)
-        self.add_series_button.clicked.connect(self._add_series)
         header_row.addWidget(self.add_series_button)
         layout.addLayout(header_row)
 
@@ -310,20 +311,24 @@ class DataTab(QWidget):
         """Per-row delete icon (replaces the old single bottom Remove button
         so a specific series/fit can be removed regardless of which entry
         is selected/expanded)."""
-        button = PButton("\U0001f5d1", role="destructive", icon=True)  # wastebasket emoji
+        button = PButton(
+            "\U0001f5d1", role="destructive", icon=True,  # wastebasket emoji
+            on_click=lambda _checked=False, i=index: self._remove_series_at(i)
+        )
         button.setFixedWidth(24)
         button.setCursor(Qt.CursorShape.PointingHandCursor)
         button.setToolTip("Remove")
-        button.clicked.connect(lambda _checked=False, i=index: self._remove_series_at(i))
         return button
 
     def _build_chevron_button(self, index: int, expanded: bool) -> QPushButton:
         """Accordion toggle: purely visual expand/collapse, independent of
         selection (see `_toggle_card_expanded`)."""
-        chevron = PButton("▾" if expanded else "▸", role="secondary", icon=True)
+        chevron = PButton(
+            "▾" if expanded else "▸", role="secondary", icon=True,
+            on_click=lambda _checked=False, i=index: self._toggle_card_expanded(i)
+        )
         chevron.setFixedWidth(24)
         chevron.setCursor(Qt.CursorShape.PointingHandCursor)
-        chevron.clicked.connect(lambda _checked=False, i=index: self._toggle_card_expanded(i))
         return chevron
 
     def _install_select_on_click(self, card: QWidget, index: int):
@@ -511,9 +516,10 @@ class DataTab(QWidget):
             self._expanded_card_y_axis_badge_tokens = tokens
             header.addWidget(badge)
         header.addWidget(self._build_trash_button(index))
-        chevron = PButton("▾", role="secondary", icon=True)  # ▾, indicates "currently expanded"
+        chevron = PButton(
+            "▾", role="secondary", icon=True, enabled=False
+        )  # ▾, indicates "currently expanded"
         chevron.setFixedWidth(24)
-        chevron.setEnabled(False)
         header.addWidget(chevron)
         outer.addLayout(header)
 

--- a/pandaplot/gui/components/sidebar/chart/tabs/style_tab.py
+++ b/pandaplot/gui/components/sidebar/chart/tabs/style_tab.py
@@ -766,8 +766,10 @@ class StyleTab(QWidget):
 
         copy_button = None
         if prefix in ("y", "y2"):
-            copy_button = PButton("Copy style to Y axis", role="secondary")
-            copy_button.clicked.connect(lambda _checked=False, p=prefix: self._on_copy_axis_style(p))
+            copy_button = PButton(
+                "Copy style to Y axis", role="secondary",
+                on_click=lambda _checked=False, p=prefix: self._on_copy_axis_style(p)
+            )
             form_layout.addWidget(copy_button)
 
         self.axes_style_forms[prefix] = {

--- a/pandaplot/gui/components/sidebar/fit/fit_panel.py
+++ b/pandaplot/gui/components/sidebar/fit/fit_panel.py
@@ -289,7 +289,7 @@ class FitPanel(SidebarPanel):
         self.apply_button = PButton("Apply", role="secondary", on_click=self._apply_fit, enabled=False)
         button_layout.addWidget(self.apply_button)
 
-        self.clear_button = PButton("Clear Results", role="secondary")
+        self.clear_button = PButton("Clear Results", role="secondary", on_click=self._clear_results)
         button_layout.addWidget(self.clear_button)
         
         layout.addLayout(button_layout)
@@ -298,8 +298,7 @@ class FitPanel(SidebarPanel):
         """Connect widget signals."""
         self.fit_type_combo.currentTextChanged.connect(self._on_fit_type_changed)
         self.series_combo.currentIndexChanged.connect(self._on_series_changed)
-        self.clear_button.clicked.connect(self._clear_results)
-    
+
     def setup_event_subscriptions(self):
         """Set up event subscriptions for tab changes."""
         self.subscribe_to_event(UIEvents.TAB_CHANGED, self._on_tab_changed)

--- a/pandaplot/gui/components/sidebar/fit/fit_panel.py
+++ b/pandaplot/gui/components/sidebar/fit/fit_panel.py
@@ -205,7 +205,10 @@ class FitPanel(SidebarPanel):
         self.custom_function_edit.setPlaceholderText("e.g., a*x**2 + b*x + c")
         custom_layout.addWidget(self.custom_function_edit, 0, 1)
         #show menu
-        self.function_button = PButton("Functions", role="secondary")
+        self.function_button = PButton(
+            "Functions", role="secondary",
+            on_click=lambda: self.menu.exec_(self.function_button.mapToGlobal(self.function_button.rect().bottomLeft()))
+        )
         custom_layout.addWidget(self.function_button, 0, 2)
         self.menu = QMenu()
         self.function_names = ["sin", "cos","tan", "sqrt", "exp", "log", "arcsin", "arccos"]
@@ -215,11 +218,6 @@ class FitPanel(SidebarPanel):
             action = self.menu.addAction(name)
             action.triggered.connect(lambda checked, f=name: self.fit_command.insert_function(f + "("))
 
-        #connect buttons to menu
-        self.function_button.clicked.connect(
-            lambda: self.menu.exec_(self.function_button.mapToGlobal(self.function_button.rect().bottomLeft()))
-        )
-        
         custom_layout.addWidget(QLabel("Parameters:"), 1, 0)
         self.custom_params_edit = QLineEdit()
         self.custom_params_edit.setPlaceholderText("e.g., a, b, c")
@@ -283,12 +281,12 @@ class FitPanel(SidebarPanel):
         """Create action buttons."""
         button_layout = QHBoxLayout()
 
-        self.fit_button = PButton("Perform Fit", role="primary")
-        self.fit_button.setEnabled(self.scipy_available)
+        self.fit_button = PButton(
+            "Perform Fit", role="primary", on_click=self.fit_command.perform_fit, enabled=self.scipy_available
+        )
         button_layout.addWidget(self.fit_button)
 
-        self.apply_button = PButton("Apply", role="secondary")
-        self.apply_button.setEnabled(False)
+        self.apply_button = PButton("Apply", role="secondary", on_click=self._apply_fit, enabled=False)
         button_layout.addWidget(self.apply_button)
 
         self.clear_button = PButton("Clear Results", role="secondary")
@@ -300,8 +298,6 @@ class FitPanel(SidebarPanel):
         """Connect widget signals."""
         self.fit_type_combo.currentTextChanged.connect(self._on_fit_type_changed)
         self.series_combo.currentIndexChanged.connect(self._on_series_changed)
-        self.fit_button.clicked.connect(self.fit_command.perform_fit)
-        self.apply_button.clicked.connect(self._apply_fit)
         self.clear_button.clicked.connect(self._clear_results)
     
     def setup_event_subscriptions(self):

--- a/pandaplot/gui/components/sidebar/icon_bar.py
+++ b/pandaplot/gui/components/sidebar/icon_bar.py
@@ -160,10 +160,11 @@ class IconBar(PWidget):
         # Add stretch to push main panel buttons to top and settings to bottom
         self.button_layout.addStretch()
         
-        self.settings_button = PButton("⚙️", role="secondary", icon=True)
         # TODO: use command instead of signal
         # TODO: make settings button addition more generic so that icon bar doesn't know about settings
-        self.settings_button.clicked.connect(self.settings_requested.emit)
+        self.settings_button = PButton(
+            "⚙️", role="secondary", icon=True, on_click=self.settings_requested.emit
+        )
         # Emoji glyph needs a larger font size than the icon-shape QSS sets by default
         self.settings_button.setStyleSheet("font-size: 16px;")
         self.settings_button.setToolTip("Settings")

--- a/pandaplot/gui/components/sidebar/preprocessing/preprocessing_panel.py
+++ b/pandaplot/gui/components/sidebar/preprocessing/preprocessing_panel.py
@@ -152,8 +152,7 @@ class PreprocessingPanel(SidebarPanel):
         group = QGroupBox("Preview")
         group_layout = QVBoxLayout()
 
-        self.preview_btn = PButton("🔍 Preview", role="secondary")
-        self.preview_btn.clicked.connect(self.preview)
+        self.preview_btn = PButton("Preview", role="secondary", on_click=self.preview)
 
         self.preview_text = QTextEdit()
         self.preview_text.setReadOnly(True)
@@ -169,11 +168,9 @@ class PreprocessingPanel(SidebarPanel):
         """Create the apply/clear buttons."""
         button_layout = QHBoxLayout()
 
-        self.apply_btn = PButton("Apply", role="primary")
-        self.apply_btn.clicked.connect(self.apply)
+        self.apply_btn = PButton("Apply", role="primary", on_click=self.apply)
 
-        self.clear_btn = PButton("🔄 Clear", role="secondary")
-        self.clear_btn.clicked.connect(self.clear_inputs)
+        self.clear_btn = PButton("Clear", role="secondary", on_click=self.clear_inputs)
 
         button_layout.addWidget(self.apply_btn)
         button_layout.addWidget(self.clear_btn)

--- a/pandaplot/gui/components/sidebar/signal/signal_panel.py
+++ b/pandaplot/gui/components/sidebar/signal/signal_panel.py
@@ -101,8 +101,7 @@ class SignalPanel(SidebarPanel):
         results_group = QGroupBox("Results")
         results_layout = QVBoxLayout()
 
-        self.run_btn = PButton("▶ Run Analysis", role="secondary")
-        self.run_btn.clicked.connect(self.run_analysis)
+        self.run_btn = PButton("Run", role="secondary", on_click=self.run_analysis)
 
         results_layout.addWidget(self.run_btn)
 
@@ -116,12 +115,11 @@ class SignalPanel(SidebarPanel):
 
         button_layout = QHBoxLayout()
 
-        self.add_btn = PButton("➕ Add Results to Project", role="primary")
-        self.add_btn.clicked.connect(self.add_results_to_project)
-        self.add_btn.setEnabled(False)
+        self.add_btn = PButton(
+            "Add to Project", role="primary", on_click=self.add_results_to_project, enabled=False
+        )
 
-        self.clear_btn = PButton("🔄 Clear", role="secondary")
-        self.clear_btn.clicked.connect(self.clear)
+        self.clear_btn = PButton("Clear", role="secondary", on_click=self.clear)
 
         button_layout.addWidget(self.add_btn)
         button_layout.addWidget(self.clear_btn)

--- a/pandaplot/gui/components/sidebar/statistics/descriptive_panel.py
+++ b/pandaplot/gui/components/sidebar/statistics/descriptive_panel.py
@@ -77,8 +77,9 @@ class DescriptiveStatsPanel(SidebarPanel):
         self._apply_hint_label_theme(hint)
         group_layout.addWidget(hint)
 
-        self.select_all_btn = PButton("Select all", role="secondary")
-        self.select_all_btn.clicked.connect(self.column_list.selectAll)
+        self.select_all_btn = PButton(
+            "Select all", role="secondary", on_click=self.column_list.selectAll
+        )
         group_layout.addWidget(self.select_all_btn)
 
         group.setLayout(group_layout)
@@ -108,8 +109,7 @@ class DescriptiveStatsPanel(SidebarPanel):
         group = QGroupBox("Results")
         group_layout = QVBoxLayout()
 
-        self.run_btn = PButton("▶ Compute", role="secondary")
-        self.run_btn.clicked.connect(self.compute)
+        self.run_btn = PButton("Compute", role="secondary", on_click=self.compute)
         group_layout.addWidget(self.run_btn)
 
         self.results_text = QTextEdit()
@@ -124,12 +124,11 @@ class DescriptiveStatsPanel(SidebarPanel):
     def _create_action_buttons(self, layout):
         button_layout = QHBoxLayout()
 
-        self.add_btn = PButton("➕ Add Results to Project", role="primary")
-        self.add_btn.clicked.connect(self.add_results_to_project)
-        self.add_btn.setEnabled(False)
+        self.add_btn = PButton(
+            "Add to Project", role="primary", on_click=self.add_results_to_project, enabled=False
+        )
 
-        self.clear_btn = PButton("🔄 Clear", role="secondary")
-        self.clear_btn.clicked.connect(self.clear)
+        self.clear_btn = PButton("Clear", role="secondary", on_click=self.clear)
 
         button_layout.addWidget(self.add_btn)
         button_layout.addWidget(self.clear_btn)

--- a/pandaplot/gui/components/sidebar/statistics/statistics_panel.py
+++ b/pandaplot/gui/components/sidebar/statistics/statistics_panel.py
@@ -83,10 +83,9 @@ class StatisticsPanel(SidebarPanel):
         selector_row = QHBoxLayout()
         selector_row.setContentsMargins(0, 0, 0, 0)
         selector_row.addWidget(self.test_type_combo, 1)
-        self.info_btn = PButton("ℹ️", role="secondary", icon=True)
+        self.info_btn = PButton("ℹ️", role="secondary", icon=True, on_click=self._show_test_info)
         self.info_btn.setFixedWidth(32)
         self.info_btn.setToolTip("Learn about this test: explanation, formula and an example")
-        self.info_btn.clicked.connect(self._show_test_info)
         selector_row.addWidget(self.info_btn)
         form.addRow("Test:", selector_row)
         group_layout.addLayout(form)
@@ -118,8 +117,7 @@ class StatisticsPanel(SidebarPanel):
         group = QGroupBox("Results")
         group_layout = QVBoxLayout()
 
-        self.run_btn = PButton("▶ Run Test", role="secondary")
-        self.run_btn.clicked.connect(self.run_test)
+        self.run_btn = PButton("Run", role="secondary", on_click=self.run_test)
         group_layout.addWidget(self.run_btn)
 
         self.results_text = QTextEdit()
@@ -134,12 +132,11 @@ class StatisticsPanel(SidebarPanel):
     def _create_action_buttons(self, layout):
         button_layout = QHBoxLayout()
 
-        self.add_btn = PButton("➕ Add Results to Project", role="primary")
-        self.add_btn.clicked.connect(self.add_results_to_project)
-        self.add_btn.setEnabled(False)
+        self.add_btn = PButton(
+            "Add to Project", role="primary", on_click=self.add_results_to_project, enabled=False
+        )
 
-        self.clear_btn = PButton("🔄 Clear", role="secondary")
-        self.clear_btn.clicked.connect(self.clear)
+        self.clear_btn = PButton("Clear", role="secondary", on_click=self.clear)
 
         button_layout.addWidget(self.add_btn)
         button_layout.addWidget(self.clear_btn)

--- a/pandaplot/gui/components/sidebar/transform/transform_panel.py
+++ b/pandaplot/gui/components/sidebar/transform/transform_panel.py
@@ -271,7 +271,7 @@ class TransformPanel(SidebarPanel):
         
         # Preview controls
         preview_controls = QHBoxLayout()
-        self.preview_btn = PButton("Preview", role="secondary")
+        self.preview_btn = PButton("Preview", role="secondary", on_click=self.update_preview)
         self.preview_btn.setMaximumWidth(70)
         
         self.preview_rows_combo = QComboBox()
@@ -293,10 +293,10 @@ class TransformPanel(SidebarPanel):
         """Create action buttons section."""
         button_layout = QHBoxLayout()
         
-        self.apply_btn = PButton("Apply", role="primary")
+        self.apply_btn = PButton("Apply", role="primary", on_click=self.apply_transform)
         # Remove hardcoded styling - will be applied in _apply_theme
 
-        self.clear_btn = PButton("Clear", role="secondary")
+        self.clear_btn = PButton("Clear", role="secondary", on_click=self.clear_panel)
         # Remove hardcoded styling - will be applied in _apply_theme
         
         button_layout.addWidget(self.apply_btn)
@@ -308,10 +308,7 @@ class TransformPanel(SidebarPanel):
         """Set up signal connections."""
         self.transform_type_combo.currentTextChanged.connect(self.on_transform_type_changed)
         self.source_column_list.itemSelectionChanged.connect(self.on_source_column_changed)
-        self.preview_btn.clicked.connect(self.update_preview)
-        self.apply_btn.clicked.connect(self.apply_transform)
-        self.clear_btn.clicked.connect(self.clear_panel)
-        
+
         # Quick function buttons
         self.multiply_btn.clicked.connect(lambda: self.insert_quick_function("x * 2"))
         self.square_btn.clicked.connect(lambda: self.insert_quick_function("x ** 2"))

--- a/pandaplot/gui/components/tabs/dataset/dataset_tab.py
+++ b/pandaplot/gui/components/tabs/dataset/dataset_tab.py
@@ -142,13 +142,13 @@ class DatasetTab(PWidget):
         actions_layout.setContentsMargins(0, 5, 0, 0)
 
         # Create chart button
-        self.create_chart_btn = PButton("📈 Create Chart from Data", role="primary")
-        self.create_chart_btn.clicked.connect(self.create_chart_from_data)
+        self.create_chart_btn = PButton(
+            "Create Chart", role="primary", on_click=self.create_chart_from_data
+        )
         actions_layout.addWidget(self.create_chart_btn)
 
         # Export data button
-        self.export_btn = PButton("💾 Export Data", role="secondary")
-        self.export_btn.clicked.connect(self.export_data)
+        self.export_btn = PButton("Export Data", role="secondary", on_click=self.export_data)
         actions_layout.addWidget(self.export_btn)
 
         # Add stretch to push buttons to the left

--- a/pandaplot/gui/dialogs/about_dialog.py
+++ b/pandaplot/gui/dialogs/about_dialog.py
@@ -96,9 +96,8 @@ class AboutDialog(PDialog):
 
         button_layout = QHBoxLayout()
         button_layout.addStretch()
-        self.close_btn = PButton("Close", role="secondary")
+        self.close_btn = PButton("Close", role="secondary", on_click=self.accept)
         self.close_btn.setDefault(True)
-        self.close_btn.clicked.connect(self.accept)
         button_layout.addWidget(self.close_btn)
         button_layout.addStretch()
         layout.addLayout(button_layout)

--- a/pandaplot/gui/dialogs/analysis/base_analysis_dialog.py
+++ b/pandaplot/gui/dialogs/analysis/base_analysis_dialog.py
@@ -122,8 +122,9 @@ class BaseAnalysisDialog(QDialog):
         group = QGroupBox("Preview")
         layout = QVBoxLayout()
         
-        preview_btn = PButton("Preview Analysis", role="secondary")
-        preview_btn.clicked.connect(self.preview_analysis)
+        preview_btn = PButton(
+            "Preview Analysis", role="secondary", on_click=self.preview_analysis
+        )
         
         self.preview_text = QTextEdit()
         self.preview_text.setMaximumHeight(150)

--- a/pandaplot/gui/dialogs/chart/chart_data_page.py
+++ b/pandaplot/gui/dialogs/chart/chart_data_page.py
@@ -46,9 +46,10 @@ class ChartDataPage(PWizardPage):
         header_row = QHBoxLayout()
         header_row.addWidget(SectionHeader("Series"))
         header_row.addStretch(1)
-        self.add_series_button = PButton("+ Add series", role="secondary")
+        self.add_series_button = PButton(
+            "+ Add series", role="secondary", on_click=self._add_card
+        )
         self.add_series_button.setCursor(Qt.CursorShape.PointingHandCursor)
-        self.add_series_button.clicked.connect(self._add_card)
         header_row.addWidget(self.add_series_button)
         content.addLayout(header_row)
 

--- a/pandaplot/gui/dialogs/chart/series_config_card.py
+++ b/pandaplot/gui/dialogs/chart/series_config_card.py
@@ -61,8 +61,9 @@ class SeriesConfigCard(Card):
         summary_layout.addWidget(self.summary_label, 1)
         self._error_status_label = QLabel()
         summary_layout.addWidget(self._error_status_label)
-        self._expand_button = PButton("▸", role="secondary", icon=True)
-        self._expand_button.clicked.connect(lambda: self.set_collapsed(False))
+        self._expand_button = PButton(
+            "▸", role="secondary", icon=True, on_click=lambda: self.set_collapsed(False)
+        )
         summary_layout.addWidget(self._expand_button)
         outer.addWidget(self._summary_row)
 
@@ -73,8 +74,9 @@ class SeriesConfigCard(Card):
 
         collapse_row = QHBoxLayout()
         collapse_row.addStretch(1)
-        self._collapse_button = PButton("▾", role="secondary", icon=True)
-        self._collapse_button.clicked.connect(lambda: self.set_collapsed(True))
+        self._collapse_button = PButton(
+            "▾", role="secondary", icon=True, on_click=lambda: self.set_collapsed(True)
+        )
         collapse_row.addWidget(self._collapse_button)
         grid.addLayout(collapse_row, row, 0, 1, 2)
         row += 1
@@ -113,8 +115,9 @@ class SeriesConfigCard(Card):
 
             self._set_error_controls_visible(False)
 
-        self.remove_button = PButton("Remove", role="destructive")
-        self.remove_button.clicked.connect(self.removeRequested.emit)
+        self.remove_button = PButton(
+            "Remove", role="destructive", on_click=self.removeRequested.emit
+        )
         grid.addWidget(self.remove_button, row, 0, 1, 2)
 
         outer.addWidget(self._form_widget)

--- a/pandaplot/gui/dialogs/chart/wizard_footer.py
+++ b/pandaplot/gui/dialogs/chart/wizard_footer.py
@@ -58,7 +58,7 @@ class WizardFooter(QWidget):
         layout.addWidget(self.next_button)
 
         self.finish_button = PButton(
-            "Create chart", role="primary", on_click=self.finishClicked.emit, parent=self
+            "Create Chart", role="primary", on_click=self.finishClicked.emit, parent=self
         )
         self.finish_button.setVisible(is_last_step)
         layout.addWidget(self.finish_button)

--- a/pandaplot/gui/dialogs/chart/wizard_footer.py
+++ b/pandaplot/gui/dialogs/chart/wizard_footer.py
@@ -39,24 +39,28 @@ class WizardFooter(QWidget):
 
         layout.addStretch(1)
 
-        self.back_button = PButton("Back", role="secondary", parent=self)
+        self.back_button = PButton(
+            "Back", role="secondary", on_click=self.backClicked.emit, parent=self
+        )
         self.back_button.setVisible(step_number > 1)
-        self.back_button.clicked.connect(self.backClicked.emit)
         layout.addWidget(self.back_button)
 
-        self.cancel_button = PButton("Cancel", role="secondary", parent=self)
-        self.cancel_button.clicked.connect(self.cancelClicked.emit)
+        self.cancel_button = PButton(
+            "Cancel", role="secondary", on_click=self.cancelClicked.emit, parent=self
+        )
         layout.addWidget(self.cancel_button)
 
         is_last_step = step_number == total_steps
-        self.next_button = PButton("Next", role="primary", parent=self)
+        self.next_button = PButton(
+            "Next", role="primary", on_click=self.nextClicked.emit, parent=self
+        )
         self.next_button.setVisible(not is_last_step)
-        self.next_button.clicked.connect(self.nextClicked.emit)
         layout.addWidget(self.next_button)
 
-        self.finish_button = PButton("Create chart", role="primary", parent=self)
+        self.finish_button = PButton(
+            "Create chart", role="primary", on_click=self.finishClicked.emit, parent=self
+        )
         self.finish_button.setVisible(is_last_step)
-        self.finish_button.clicked.connect(self.finishClicked.emit)
         layout.addWidget(self.finish_button)
 
     def set_back_enabled(self, enabled: bool) -> None:

--- a/pandaplot/gui/dialogs/examples_dialog.py
+++ b/pandaplot/gui/dialogs/examples_dialog.py
@@ -82,8 +82,7 @@ class ExamplesDialog(PDialog):
         # top-level import of PButton (under gui.components.common) would fail.
         from pandaplot.gui.components.common.p_button import PButton
 
-        self.close_btn = PButton("Cancel", role="secondary")
-        self.close_btn.clicked.connect(self.reject)
+        self.close_btn = PButton("Cancel", role="secondary", on_click=self.reject)
         layout.addWidget(self.close_btn, alignment=Qt.AlignmentFlag.AlignRight)
 
     def _create_example_item(self, example: dict) -> QPushButton:

--- a/pandaplot/gui/dialogs/import_wizard_dialog.py
+++ b/pandaplot/gui/dialogs/import_wizard_dialog.py
@@ -176,8 +176,7 @@ class ImportWizardDialog(PDialog):
         self.file_path_label.setTextInteractionFlags(Qt.TextInteractionFlag.TextSelectableByMouse)
         row.addWidget(self.file_path_label, 1)
 
-        self.browse_button = PButton("Browse…", role="secondary")
-        self.browse_button.clicked.connect(self._browse_file)
+        self.browse_button = PButton("Browse…", role="secondary", on_click=self._browse_file)
         row.addWidget(self.browse_button, 0)
 
         parent_layout.addLayout(row)
@@ -272,13 +271,11 @@ class ImportWizardDialog(PDialog):
         row.setContentsMargins(0, 0, 0, 0)
         row.addStretch(1)
 
-        self.cancel_button = PButton("Cancel", role="secondary")
-        self.cancel_button.clicked.connect(self.reject)
+        self.cancel_button = PButton("Cancel", role="secondary", on_click=self.reject)
         row.addWidget(self.cancel_button)
 
-        self.import_button = PButton("Import", role="primary")
+        self.import_button = PButton("Import", role="primary", on_click=self.accept)
         self.import_button.setDefault(True)
-        self.import_button.clicked.connect(self.accept)
         row.addWidget(self.import_button)
 
         parent_layout.addWidget(self.button_frame)

--- a/pandaplot/gui/dialogs/settings_dialog.py
+++ b/pandaplot/gui/dialogs/settings_dialog.py
@@ -62,7 +62,7 @@ class SettingsDialog(PDialog):
     @override
     def _init_ui(self):
         """Set up the user interface."""
-        self.setWindowTitle("⚙️ Application Settings")
+        self.setWindowTitle("Application Settings")
         self.setModal(True)
         self.resize(700, 500)
         self.setMinimumSize(650, 450)
@@ -162,6 +162,13 @@ class SettingsDialog(PDialog):
             QCheckBox {{
                 color: {base_fg};
             }}
+            QScrollArea {{
+                border: none;
+                background-color: {card_bg};
+            }}
+            QScrollArea > QWidget > QWidget {{
+                background-color: {card_bg};
+            }}
         """)
         
         # Apply styling to button frame
@@ -194,7 +201,7 @@ class SettingsDialog(PDialog):
         layout.setContentsMargins(20, 20, 20, 20)
         layout.setSpacing(15)
 
-        autosave_group = QGroupBox("💾 Auto Save")
+        autosave_group = QGroupBox("Auto Save")
         ag_layout = QVBoxLayout(autosave_group)
         self.auto_save_check = QCheckBox("Enable automatic project saving")
         ag_layout.addWidget(self.auto_save_check)
@@ -210,7 +217,7 @@ class SettingsDialog(PDialog):
         layout.addWidget(autosave_group)
 
         # Chart display group (preview settings like DPI)
-        chart_group = QGroupBox("📈 Chart Display Settings")
+        chart_group = QGroupBox("Chart Display Settings")
         cd_layout = QVBoxLayout(chart_group)
         
         # DPI setting
@@ -256,7 +263,7 @@ class SettingsDialog(PDialog):
         layout.addWidget(chart_group)
 
         layout.addStretch()
-        self.tab_widget.addTab(tab, "⚙️ General")
+        self.tab_widget.addTab(tab, "General")
 
     def create_appearance_tab(self):
         """Create the appearance settings tab with scroll area to avoid clipping."""
@@ -272,10 +279,10 @@ class SettingsDialog(PDialog):
         container = QWidget()
         cont_layout = QVBoxLayout(container)
         cont_layout.setContentsMargins(20, 20, 20, 20)
-        cont_layout.setSpacing(18)
+        cont_layout.setSpacing(15)
 
         # Theme group
-        theme_group = QGroupBox("🎨 Theme and Colors")
+        theme_group = QGroupBox("Theme and Colors")
         theme_layout = QVBoxLayout(theme_group)
         theme_selection_layout = QHBoxLayout()
         theme_selection_layout.addWidget(QLabel("Application theme:"))
@@ -307,7 +314,7 @@ class SettingsDialog(PDialog):
         cont_layout.addWidget(theme_group)
 
         # Font group
-        font_group = QGroupBox("🔤 Fonts")
+        font_group = QGroupBox("Fonts")
         font_layout = QVBoxLayout(font_group)
         interface_font_layout = QHBoxLayout()
         interface_font_layout.addWidget(QLabel("Interface font size:"))
@@ -331,7 +338,7 @@ class SettingsDialog(PDialog):
         cont_layout.addStretch()
 
         scroll.setWidget(container)
-        self.tab_widget.addTab(tab, "🎨 Appearance")
+        self.tab_widget.addTab(tab, "Appearance")
     
     def create_editor_tab(self):
         """Create the editor settings tab."""
@@ -341,7 +348,7 @@ class SettingsDialog(PDialog):
         layout.setSpacing(15)
         
         # Text editing group
-        editing_group = QGroupBox("📝 Text Editing")
+        editing_group = QGroupBox("Text Editing")
         editing_layout = QVBoxLayout(editing_group)
         
         # Word wrap
@@ -367,7 +374,7 @@ class SettingsDialog(PDialog):
         
         layout.addWidget(editing_group)
         layout.addStretch()
-        self.tab_widget.addTab(tab, "📝 Editor")
+        self.tab_widget.addTab(tab, "Editor")
     
     def create_buttons(self, layout):
         """Create the button frame."""
@@ -382,25 +389,23 @@ class SettingsDialog(PDialog):
         button_layout.setContentsMargins(16, 12, 16, 12)
         
         # Reset button
-        self.reset_btn = PButton("🔄 Reset to Defaults", role="secondary")
-        self.reset_btn.clicked.connect(self.reset_to_defaults)
+        self.reset_btn = PButton(
+            "Reset to Defaults", role="secondary", on_click=self.reset_to_defaults
+        )
         button_layout.addWidget(self.reset_btn)
 
         button_layout.addStretch()
 
         # Cancel button
-        self.cancel_btn = PButton("❌ Cancel", role="secondary")
-        self.cancel_btn.clicked.connect(self.reject)
+        self.cancel_btn = PButton("Cancel", role="secondary", on_click=self.reject)
         button_layout.addWidget(self.cancel_btn)
 
         # Apply button
-        self.apply_btn = PButton("Apply", role="primary")
-        self.apply_btn.clicked.connect(self.apply_settings)
+        self.apply_btn = PButton("Apply", role="primary", on_click=self.apply_settings)
         button_layout.addWidget(self.apply_btn)
 
         # OK button
-        self.ok_btn = PButton("💾 OK", role="primary")
-        self.ok_btn.clicked.connect(self.accept_settings)
+        self.ok_btn = PButton("OK", role="primary", on_click=self.accept_settings)
         self.ok_btn.setDefault(True)
         button_layout.addWidget(self.ok_btn)
         

--- a/tests/gui/common/test_p_button.py
+++ b/tests/gui/common/test_p_button.py
@@ -53,3 +53,34 @@ def test_set_role_changes_role_at_runtime():
 def test_button_text_is_preserved():
     button = PButton("Apply", role="primary")
     assert button.text() == "Apply"
+
+
+def test_on_click_connects_handler():
+    calls = []
+    button = PButton("Apply", role="primary", on_click=lambda: calls.append(True))
+    button.click()
+    assert calls == [True]
+
+
+def test_omitting_on_click_makes_no_connection():
+    button = PButton("Apply", role="primary")
+    button.click()  # must not raise with no handler attached
+
+
+def test_enabled_false_disables_button_at_construction():
+    button = PButton("Apply", role="primary", enabled=False)
+    assert button.isEnabled() is False
+
+
+def test_enabled_defaults_to_true():
+    button = PButton("Apply", role="primary")
+    assert button.isEnabled() is True
+
+
+def test_on_click_and_enabled_false_compose():
+    calls = []
+    button = PButton("Fit", role="primary", on_click=lambda: calls.append(True), enabled=False)
+    assert button.isEnabled() is False
+    button.setEnabled(True)
+    button.click()
+    assert calls == [True]

--- a/tests/gui/common/test_p_button.py
+++ b/tests/gui/common/test_p_button.py
@@ -84,3 +84,17 @@ def test_on_click_and_enabled_false_compose():
     button.setEnabled(True)
     button.click()
     assert calls == [True]
+
+
+def test_on_click_accepts_a_qt_signal():
+    from PySide6.QtCore import QObject, Signal
+
+    class _Emitter(QObject):
+        fired = Signal()
+
+    emitter = _Emitter()
+    calls = []
+    emitter.fired.connect(lambda: calls.append(True))
+    button = PButton("Apply", role="primary", on_click=emitter.fired)
+    button.click()
+    assert calls == [True]

--- a/tests/gui/sidebar/test_fit_panel.py
+++ b/tests/gui/sidebar/test_fit_panel.py
@@ -1,0 +1,62 @@
+"""Smoke tests for FitPanel construction.
+
+FitPanel moved its `apply_button`/`fit_button`/`clear_button` `.clicked.connect(...)`
+calls into the constructor via PButton's `on_click=`/`enabled=` params. That made
+construction order matter: `fit_button` is built with `enabled=self.scipy_available`,
+which requires `self.scipy_available` to already be assigned before
+`_create_action_buttons` runs. Nothing previously constructed FitPanel in tests, so a
+future construction-order regression (e.g. reordering the scipy check after UI setup)
+would go unnoticed. These tests just build the panel and check the buttons exist.
+"""
+from unittest.mock import Mock
+
+import pytest
+from PySide6.QtWidgets import QApplication
+
+from pandaplot.gui.components.common.p_button import PButton
+from pandaplot.gui.components.sidebar.fit.fit_panel import FitPanel
+from pandaplot.models.state.app_context import AppContext
+
+
+@pytest.fixture(scope="module", autouse=True)
+def qapp():
+    app = QApplication.instance() or QApplication([])
+    yield app
+
+
+@pytest.fixture
+def app_context():
+    ctx = Mock(spec=AppContext)
+    ctx.event_bus = Mock()
+    return ctx
+
+
+@pytest.fixture
+def fit_panel(app_context):
+    return FitPanel(app_context)
+
+
+def test_fit_panel_constructs_with_expected_buttons(fit_panel):
+    assert isinstance(fit_panel.fit_button, PButton)
+    assert isinstance(fit_panel.apply_button, PButton)
+    assert isinstance(fit_panel.clear_button, PButton)
+
+
+def test_fit_button_enabled_state_matches_scipy_availability(fit_panel):
+    # Directly covers the construction-order-sensitive `enabled=self.scipy_available`
+    # retrofit: fit_button's enabled state must reflect scipy_available as computed
+    # at construction time, not some later/default value.
+    assert fit_panel.fit_button.isEnabled() == fit_panel.scipy_available
+
+
+def test_apply_button_starts_disabled(fit_panel):
+    assert fit_panel.apply_button.isEnabled() is False
+
+
+def test_clear_button_click_invokes_clear_results(app_context):
+    panel = FitPanel(app_context)
+    panel.results_text.setPlainText("some results")
+
+    panel.clear_button.click()
+
+    assert panel.results_text.toPlainText() == ""

--- a/tests/gui/sidebar/test_transform_panel.py
+++ b/tests/gui/sidebar/test_transform_panel.py
@@ -1,0 +1,47 @@
+"""Smoke tests for TransformPanel construction.
+
+TransformPanel moved its `apply_btn`/`clear_btn`/`preview_btn` `.clicked.connect(...)`
+calls into the constructor via PButton's `on_click=` param. Nothing previously
+constructed TransformPanel in tests, so a future construction-order regression would
+go unnoticed. These tests just build the panel and check the buttons exist.
+"""
+from unittest.mock import Mock
+
+import pytest
+from PySide6.QtWidgets import QApplication
+
+from pandaplot.gui.components.common.p_button import PButton
+from pandaplot.gui.components.sidebar.transform.transform_panel import TransformPanel
+from pandaplot.models.state.app_context import AppContext
+
+
+@pytest.fixture(scope="module", autouse=True)
+def qapp():
+    app = QApplication.instance() or QApplication([])
+    yield app
+
+
+@pytest.fixture
+def app_context():
+    ctx = Mock(spec=AppContext)
+    ctx.event_bus = Mock()
+    return ctx
+
+
+@pytest.fixture
+def transform_panel(app_context):
+    return TransformPanel(app_context)
+
+
+def test_transform_panel_constructs_with_expected_buttons(transform_panel):
+    assert isinstance(transform_panel.apply_btn, PButton)
+    assert isinstance(transform_panel.clear_btn, PButton)
+    assert isinstance(transform_panel.preview_btn, PButton)
+
+
+def test_preview_button_click_invokes_update_preview(transform_panel):
+    transform_panel.preview_text.setPlainText("stale")
+
+    transform_panel.preview_btn.click()
+
+    assert transform_panel.preview_text.toPlainText() == "No data available for preview"


### PR DESCRIPTION
## Summary

Direct follow-up to #164 (stacked on that branch, not `main` — merge #164 first).

- **`PButton` gains `on_click`/`enabled` constructor params**, folding the near-universal "construct → `.clicked.connect(...)` → maybe `.setEnabled(False)`" pattern into one call. Adopted across essentially every `PButton` call site app-wide (~30 files), including two judgment calls (verified safe in review): `FitPanel`'s and `TransformPanel`'s connects, originally in separate `_connect_signals()`/`setup_connections()` methods, moved into the constructor after confirming the handler is available at construction time.
- **Removed decorative emoji from ~18 action button labels** (Preview/Run/Compute/Clear/Add-to-Project across 5 sidebar panels, Dataset tab, Settings dialog) and **simplified 5 labels** where panel context made part of the text redundant ("Run Analysis"→"Run", "Create Chart from Data"→"Create Chart", etc.). Icon-only buttons (gear, info, trash, chevrons) are untouched — the icon *is* their content, not decoration.
- **Settings dialog**: removed 9 more decorative emoji (window title, tab labels, group box titles), and fixed the Appearance tab's visual break from its General/Editor siblings — it was wrapped in an unstyled `QScrollArea` with mismatched inner spacing (18px vs 15px); now explicitly styled to match the dialog's card background with spacing normalized.
- Final whole-branch review caught one real inconsistency (`FitPanel`'s `clear_button` was the one remaining un-retrofitted button) and two test-coverage gaps (no construction tests for `FitPanel`/`TransformPanel` — the two files where a connect crossed a method boundary; no `PButton` test covering the dominant real usage of passing a Qt Signal as `on_click` rather than a plain callable). All fixed and re-reviewed.

## Test plan

- [x] Full test suite: `pytest -q` → 977 passed (970 + 7 new: PButton signal test, FitPanel/TransformPanel construction tests)
- [x] Every task independently reviewed (spec compliance + code quality); final whole-branch review's findings applied and re-reviewed clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)